### PR TITLE
Refactor /authorize to always require client_id/client_secret credentials

### DIFF
--- a/server/authorize.go
+++ b/server/authorize.go
@@ -16,9 +16,9 @@ import (
 	"tailscale.com/util/rands"
 )
 
-// authorize handles the OAuth 2.0 authorization endpoint
+// serveAuthorize handles the OAuth 2.0 authorization endpoint
 // Migrated from legacy/tsidp.go:554-672
-func (s *IDPServer) authorize(w http.ResponseWriter, r *http.Request) {
+func (s *IDPServer) serveAuthorize(w http.ResponseWriter, r *http.Request) {
 	// This URL is visited by the user who is being authenticated. If they are
 	// visiting the URL over Funnel, that means they are not part of the
 	// tailnet that they are trying to be authenticated for.

--- a/server/authorize.go
+++ b/server/authorize.go
@@ -4,31 +4,29 @@
 package server
 
 import (
+	"crypto/subtle"
 	"fmt"
 	"log"
 	"net/http"
 	"net/url"
-	"strconv"
-	"strings"
+	"slices"
 
-	"tailscale.com/tailcfg"
+	"tailscale.com/client/tailscale/apitype"
 	"tailscale.com/util/mak"
 	"tailscale.com/util/rands"
 )
 
 // serveAuthorize handles the OAuth 2.0 authorization endpoint
-// Migrated from legacy/tsidp.go:554-672
 func (s *IDPServer) serveAuthorize(w http.ResponseWriter, r *http.Request) {
 	// This URL is visited by the user who is being authenticated. If they are
 	// visiting the URL over Funnel, that means they are not part of the
 	// tailnet that they are trying to be authenticated for.
+	// NOTE: Funnel request behavior is the same regardless of secure or insecure mode.
 	if isFunnelRequest(r) {
 		http.Error(w, "tsidp: unauthorized", http.StatusUnauthorized)
 		return
 	}
-
 	uq := r.URL.Query()
-	state := uq.Get("state")
 
 	redirectURI := uq.Get("redirect_uri")
 	if redirectURI == "" {
@@ -36,145 +34,81 @@ func (s *IDPServer) serveAuthorize(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	clientID := uq.Get("client_id")
+	if clientID == "" {
+		http.Error(w, "tsidp: must specify client_id", http.StatusBadRequest)
+		return
+	}
+
+	s.mu.Lock()
+	funnelClient, ok := s.funnelClients[clientID]
+	s.mu.Unlock()
+
+	if !ok {
+		http.Error(w, "tsidp: invalid client ID", http.StatusBadRequest)
+		return
+	}
+
+	// Validate client_id matches (public identifier validation)
+	clientIDcmp := subtle.ConstantTimeCompare([]byte(clientID), []byte(funnelClient.ID))
+	if clientIDcmp != 1 {
+		http.Error(w, "tsidp: invalid client ID", http.StatusBadRequest)
+		return
+	}
+
+	// check for exact match of redirect_uri (OAuth 2.1 requirement)
+	if !slices.Contains(funnelClient.RedirectURIs, redirectURI) {
+		http.Error(w, "tsidp: redirect_uri mismatch", http.StatusBadRequest)
+		return
+	}
+
+	// Get user information
 	var remoteAddr string
 	if s.localTSMode {
-		// in local tailscaled mode, the local tailscaled is forwarding us
-		// HTTP requests, so reading r.RemoteAddr will just get us our own
-		// address.
 		remoteAddr = r.Header.Get("X-Forwarded-For")
 	} else {
 		remoteAddr = r.RemoteAddr
 	}
-	who, err := s.lc.WhoIs(r.Context(), remoteAddr)
+
+	// Check who is visiting the authorize endpoint.
+	var who *apitype.WhoIsResponse
+	var err error
+	who, err = s.lc.WhoIs(r.Context(), remoteAddr)
 	if err != nil {
 		log.Printf("Error getting WhoIs: %v", err)
-		redirectAuthError(w, r, redirectURI, "server_error", "internal server error", state)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
+	// Generate and save a code and Auth Request
 	code := rands.HexString(32)
 	ar := &AuthRequest{
 		Nonce:       uq.Get("nonce"),
 		RemoteUser:  who,
 		RedirectURI: redirectURI,
-		ClientID:    uq.Get("client_id"),
-		Resources:   uq["resource"], // RFC 8707: multiple resource parameters are allowed
-	}
-
-	// Parse space-delimited scopes
-	if scopeParam := uq.Get("scope"); scopeParam != "" {
-		ar.Scopes = strings.Fields(scopeParam)
-	}
-
-	// Validate scopes
-	validatedScopes, err := s.validateScopes(ar.Scopes)
-	if err != nil {
-		redirectAuthError(w, r, redirectURI, "invalid_scope", fmt.Sprintf("invalid scope: %v", err), state)
-		return
-	}
-	ar.Scopes = validatedScopes
-
-	// Handle PKCE parameters (RFC 7636)
-	if codeChallenge := uq.Get("code_challenge"); codeChallenge != "" {
-		ar.CodeChallenge = codeChallenge
-
-		// code_challenge_method defaults to "plain" if not specified
-		ar.CodeChallengeMethod = uq.Get("code_challenge_method")
-		if ar.CodeChallengeMethod == "" {
-			ar.CodeChallengeMethod = "plain"
-		}
-
-		// Validate the code_challenge_method
-		if ar.CodeChallengeMethod != "plain" && ar.CodeChallengeMethod != "S256" {
-			redirectAuthError(w, r, redirectURI, "invalid_request", "unsupported code_challenge_method", state)
-			return
-		}
-	}
-
-	if r.URL.Path == "/authorize/funnel" {
-		s.mu.Lock()
-		c, ok := s.funnelClients[ar.ClientID]
-		s.mu.Unlock()
-		if !ok {
-			redirectAuthError(w, r, redirectURI, "invalid_request", "invalid client ID", state)
-			return
-		}
-		// Validate redirect_uri against the client's registered redirect URIs
-		validRedirect := false
-		for _, uri := range c.RedirectURIs {
-			if ar.RedirectURI == uri {
-				validRedirect = true
-				break
-			}
-		}
-		if !validRedirect {
-			redirectAuthError(w, r, redirectURI, "invalid_request", "redirect_uri mismatch", state)
-			return
-		}
-		ar.FunnelRP = c
-	} else if r.URL.Path == "/authorize/localhost" {
-		ar.LocalRP = true
-	} else {
-		var ok bool
-		ar.RPNodeID, ok = parseID[tailcfg.NodeID](strings.TrimPrefix(r.URL.Path, "/authorize/"))
-		if !ok {
-			redirectAuthError(w, r, redirectURI, "invalid_request", "invalid node ID suffix after /authorize/", state)
-			return
-		}
+		ClientID:    clientID,
+		FunnelRP:    funnelClient, // Store the validated client
 	}
 
 	s.mu.Lock()
 	mak.Set(&s.code, code, ar)
 	s.mu.Unlock()
 
-	q := make(url.Values)
-	q.Set("code", code)
+	queryString := make(url.Values)
+	queryString.Set("code", code)
 	if state := uq.Get("state"); state != "" {
-		q.Set("state", state)
+		queryString.Set("state", state)
 	}
-	u := redirectURI + "?" + q.Encode()
+	parsedURL, err := url.Parse(redirectURI)
+	if err != nil {
+		http.Error(w, "invalid redirect URI", http.StatusInternalServerError)
+		return
+	}
+	parsedURL.RawQuery = queryString.Encode()
+	u := parsedURL.String()
 	log.Printf("Redirecting to %q", u)
 
 	http.Redirect(w, r, u, http.StatusFound)
-}
-
-// redirectAuthError redirects to the redirect_uri with an error
-// Migrated from legacy/tsidp.go:1655-1674
-func redirectAuthError(w http.ResponseWriter, r *http.Request, redirectURI, errorCode, errorDescription, state string) {
-	u, err := url.Parse(redirectURI)
-	if err != nil {
-		// If redirect URI is invalid, return error directly
-		http.Error(w, "invalid redirect_uri", http.StatusBadRequest)
-		return
-	}
-
-	q := u.Query()
-	q.Set("error", errorCode)
-	if errorDescription != "" {
-		q.Set("error_description", errorDescription)
-	}
-	if state != "" {
-		q.Set("state", state)
-	}
-	u.RawQuery = q.Encode()
-
-	http.Redirect(w, r, u.String(), http.StatusFound)
-}
-
-// parseID parses an ID from a string
-// Migrated from legacy/tsidp.go:2377-2389
-func parseID[T ~int64](input string) (_ T, ok bool) {
-	if input == "" {
-		return 0, false
-	}
-	i, err := strconv.ParseInt(input, 10, 64)
-	if err != nil {
-		return 0, false
-	}
-	if i < 0 {
-		return 0, false
-	}
-	return T(i), true
 }
 
 // validateScopes validates the requested OAuth scopes

--- a/server/helpers_test.go
+++ b/server/helpers_test.go
@@ -16,15 +16,10 @@ import (
 	"tailscale.com/tailcfg"
 )
 
-// Test helper functions for strict OAuth mode testing
-func setupTestServer(t *testing.T, strictMode bool) *IDPServer {
-	return setupTestServerWithClient(t, strictMode, nil)
-}
-
 // setupTestServerWithClient creates a test server with an optional LocalClient.
 // If lc is nil, the server will have no LocalClient (original behavior).
 // If lc is provided, it will be used for WhoIs calls during testing.
-func setupTestServerWithClient(t *testing.T, strictMode bool, lc *local.Client) *IDPServer {
+func setupTestServer(t *testing.T, lc *local.Client) *IDPServer {
 	t.Helper()
 
 	srv := &IDPServer{
@@ -36,7 +31,7 @@ func setupTestServerWithClient(t *testing.T, strictMode bool, lc *local.Client) 
 		lc:            lc,
 	}
 
-	// Add a test client for funnel/strict mode testing
+	// Add a test client
 	srv.funnelClients["test-client"] = &FunnelClient{
 		ID:          "test-client",
 		Secret:      "test-secret",

--- a/server/server.go
+++ b/server/server.go
@@ -38,7 +38,6 @@ import (
 // Migrated from legacy/tsidp.go:58
 type CtxConn struct{}
 
-
 // IDPServer handles OIDC identity provider operations
 // Migrated from legacy/tsidp.go:306-323
 type IDPServer struct {
@@ -141,7 +140,7 @@ type ActorClaim struct {
 // signingKey represents a JWT signing key
 // Migrated from legacy/tsidp.go:2336-2339
 type signingKey struct {
-	Kid uint64        `json:"kid"`
+	Kid uint64          `json:"kid"`
 	Key *rsa.PrivateKey `json:"-"`
 }
 
@@ -174,7 +173,6 @@ func (s *IDPServer) ServerURL() string {
 func (s *IDPServer) SetLoopbackURL(url string) {
 	s.loopbackURL = url
 }
-
 
 // CleanupExpiredTokens removes expired tokens from memory
 // Migrated from legacy/tsidp.go:2280-2299
@@ -220,31 +218,31 @@ func (s *IDPServer) newMux() *http.ServeMux {
 	mux.HandleFunc("/.well-known/jwks.json", s.serveJWKS)
 	mux.HandleFunc("/.well-known/openid-configuration", s.serveOpenIDConfig)
 	mux.HandleFunc("/.well-known/oauth-authorization-server", s.serveOAuthMetadata)
-	
+
 	// Register /authorize endpoint
 	// Migrated from legacy/tsidp.go:679
-	mux.HandleFunc("/authorize/", s.authorize)
-	
+	mux.HandleFunc("/authorize/", s.serveAuthorize)
+
 	// Register /clients/ endpoint
 	// Migrated from legacy/tsidp.go:684
 	mux.HandleFunc("/clients/", s.serveClients)
-	
+
 	// Register /token endpoint
 	// Migrated from legacy/tsidp.go:681
 	mux.HandleFunc("/token", s.serveToken)
-	
+
 	// Register /introspect endpoint
 	// Migrated from legacy/tsidp.go:682
 	mux.HandleFunc("/introspect", s.serveIntrospect)
-	
+
 	// Register /userinfo endpoint
 	// Migrated from legacy/tsidp.go:680
 	mux.HandleFunc("/userinfo", s.serveUserInfo)
-	
+
 	// Register /register endpoint for Dynamic Client Registration
 	// Migrated from legacy/tsidp.go:683
 	mux.HandleFunc("/register", s.serveDynamicClientRegistration)
-	
+
 	// Register UI handler - must be last as it handles "/"
 	// Migrated from legacy/tsidp.go:685
 	mux.HandleFunc("/", s.handleUI)

--- a/server/server.go
+++ b/server/server.go
@@ -221,7 +221,7 @@ func (s *IDPServer) newMux() *http.ServeMux {
 
 	// Register /authorize endpoint
 	// Migrated from legacy/tsidp.go:679
-	mux.HandleFunc("/authorize/", s.serveAuthorize)
+	mux.HandleFunc("/authorize", s.serveAuthorize)
 
 	// Register /clients/ endpoint
 	// Migrated from legacy/tsidp.go:684

--- a/server/token.go
+++ b/server/token.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"gopkg.in/square/go-jose.v2/jwt"
-	"tailscale.com/client/local"
 	"tailscale.com/client/tailscale/apitype"
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/key"
@@ -133,7 +132,7 @@ func (s *IDPServer) handleAuthorizationCodeGrant(w http.ResponseWriter, r *http.
 		writeTokenEndpointError(w, http.StatusBadRequest, "invalid_grant", "code not found")
 		return
 	}
-	if httpStatusCode, err := ar.allowRelyingParty(r, s.lc); err != nil {
+	if httpStatusCode, err := ar.allowRelyingParty(r); err != nil {
 		//log.Printf("XXX Error allowing relying party: %v", err)
 		writeTokenEndpointError(w, httpStatusCode, "invalid_client", err.Error())
 		return
@@ -198,7 +197,7 @@ func (s *IDPServer) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Reque
 	}
 
 	// Validate client authentication
-	if httpStatusCode, err := ar.allowRelyingParty(r, s.lc); err != nil {
+	if httpStatusCode, err := ar.allowRelyingParty(r); err != nil {
 		//log.Printf("Error allowing relying party: %v", err)
 		writeTokenEndpointError(w, httpStatusCode, "invalid_client", err.Error())
 		return
@@ -405,8 +404,6 @@ func (s *IDPServer) serveTokenExchange(w http.ResponseWriter, r *http.Request) {
 		ActorInfo:        actorInfo,
 
 		// Preserve original RP context
-		LocalRP:  ar.LocalRP,
-		RPNodeID: ar.RPNodeID,
 		FunnelRP: ar.FunnelRP, // Keep original funnel client if it exists
 	}
 
@@ -524,9 +521,6 @@ func (s *IDPServer) issueTokens(w http.ResponseWriter, ar *AuthRequest) {
 			}
 			tsClaims.Picture = who.UserProfile.ProfilePicURL
 		}
-	}
-	if ar.LocalRP {
-		tsClaims.Issuer = s.loopbackURL
 	}
 
 	// Set azp (authorized party) claim when there are multiple audiences
@@ -798,13 +792,7 @@ func (s *IDPServer) serveIntrospect(w http.ResponseWriter, r *http.Request) {
 		resp["iat"] = ar.ValidTill.Add(-5 * time.Minute).Unix() // issued 5 min before expiry
 		resp["nbf"] = ar.ValidTill.Add(-5 * time.Minute).Unix() // not before time (same as iat)
 		resp["token_type"] = "Bearer"
-
-		// Add issuer claim
-		if ar.LocalRP {
-			resp["iss"] = s.loopbackURL
-		} else {
-			resp["iss"] = s.serverURL
-		}
+		resp["iss"] = s.serverURL
 
 		// Add jti if available
 		if ar.JTI != "" {
@@ -872,47 +860,28 @@ func (s *IDPServer) serveIntrospect(w http.ResponseWriter, r *http.Request) {
 
 // allowRelyingParty checks if the relying party is allowed to access the token
 // Migrated from legacy/tsidp.go:520-552
-func (ar *AuthRequest) allowRelyingParty(r *http.Request, lc *local.Client) (int, error) {
-	if ar.LocalRP {
-		ra, err := netip.ParseAddrPort(r.RemoteAddr)
-		if err != nil {
-			return http.StatusBadRequest, err
-		}
-		if !ra.Addr().IsLoopback() {
-			return http.StatusForbidden, fmt.Errorf("tsidp: request from non-loopback address")
-		}
-		return http.StatusOK, nil
+func (ar *AuthRequest) allowRelyingParty(r *http.Request) (int, error) {
+	if ar.FunnelRP == nil {
+		return http.StatusUnauthorized, fmt.Errorf("tsidp: no relying party configured")
 	}
-	if ar.FunnelRP != nil {
-		clientID, clientSecret, ok := r.BasicAuth()
-		if !ok {
-			clientID = r.FormValue("client_id")
-			clientSecret = r.FormValue("client_secret")
-		}
 
-		if clientID == "" || clientSecret == "" {
-			return http.StatusUnauthorized, fmt.Errorf("tsidp: missing client credentials")
-		}
+	clientID, clientSecret, ok := r.BasicAuth()
+	if !ok {
+		clientID = r.FormValue("client_id")
+		clientSecret = r.FormValue("client_secret")
+	}
 
-		clientIDcmp := subtle.ConstantTimeCompare([]byte(clientID), []byte(ar.FunnelRP.ID))
-		clientSecretcmp := subtle.ConstantTimeCompare([]byte(clientSecret), []byte(ar.FunnelRP.Secret))
-		if clientIDcmp != 1 {
-			return http.StatusBadRequest, fmt.Errorf("tsidp: client_id mismatch")
-		}
-		if clientSecretcmp != 1 {
-			return http.StatusUnauthorized, fmt.Errorf("tsidp: invalid client secret: [%s] [%s]", clientID, clientSecret)
-		}
-		return http.StatusOK, nil
+	if clientID == "" || clientSecret == "" {
+		return http.StatusUnauthorized, fmt.Errorf("tsidp: missing client credentials")
 	}
-	if lc == nil {
-		return http.StatusInternalServerError, fmt.Errorf("tsidp: no local client available for node validation")
+
+	clientIDcmp := subtle.ConstantTimeCompare([]byte(clientID), []byte(ar.FunnelRP.ID))
+	clientSecretcmp := subtle.ConstantTimeCompare([]byte(clientSecret), []byte(ar.FunnelRP.Secret))
+	if clientIDcmp != 1 {
+		return http.StatusBadRequest, fmt.Errorf("tsidp: client_id mismatch")
 	}
-	who, err := lc.WhoIs(r.Context(), r.RemoteAddr)
-	if err != nil {
-		return http.StatusInternalServerError, fmt.Errorf("tsidp: error getting WhoIs: %w", err)
-	}
-	if ar.RPNodeID != who.Node.ID {
-		return http.StatusForbidden, fmt.Errorf("tsidp: token for different node")
+	if clientSecretcmp != 1 {
+		return http.StatusUnauthorized, fmt.Errorf("tsidp: invalid client secret: [%s] [%s]", clientID, clientSecret)
 	}
 	return http.StatusOK, nil
 }

--- a/server/token.go
+++ b/server/token.go
@@ -9,7 +9,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"net/netip"
 	"strings"
@@ -134,9 +133,9 @@ func (s *IDPServer) handleAuthorizationCodeGrant(w http.ResponseWriter, r *http.
 		writeTokenEndpointError(w, http.StatusBadRequest, "invalid_grant", "code not found")
 		return
 	}
-	if err := ar.allowRelyingParty(r, s.lc); err != nil {
-		log.Printf("Error allowing relying party: %v", err)
-		writeTokenEndpointError(w, http.StatusUnauthorized, "invalid_client", err.Error())
+	if httpStatusCode, err := ar.allowRelyingParty(r, s.lc); err != nil {
+		//log.Printf("XXX Error allowing relying party: %v", err)
+		writeTokenEndpointError(w, httpStatusCode, "invalid_client", err.Error())
 		return
 	}
 	if ar.RedirectURI != r.FormValue("redirect_uri") {
@@ -164,7 +163,7 @@ func (s *IDPServer) handleAuthorizationCodeGrant(w http.ResponseWriter, r *http.
 		// Validate requested resources using the same capability would be used for STS
 		validatedResources, err := s.validateResourcesForUser(ar.RemoteUser, resources)
 		if err != nil {
-			log.Printf("Error validating resources: %v", err)
+			//log.Printf("Error validating resources: %v", err)
 			writeTokenEndpointError(w, http.StatusBadRequest, "invalid_request", "invalid resource")
 			return
 		}
@@ -199,9 +198,9 @@ func (s *IDPServer) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Reque
 	}
 
 	// Validate client authentication
-	if err := ar.allowRelyingParty(r, s.lc); err != nil {
-		log.Printf("Error allowing relying party: %v", err)
-		writeTokenEndpointError(w, http.StatusUnauthorized, "invalid_client", "")
+	if httpStatusCode, err := ar.allowRelyingParty(r, s.lc); err != nil {
+		//log.Printf("Error allowing relying party: %v", err)
+		writeTokenEndpointError(w, httpStatusCode, "invalid_client", err.Error())
 		return
 	}
 
@@ -211,8 +210,8 @@ func (s *IDPServer) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Reque
 		// Validate requested resources are a subset of original grant
 		validatedResources, err := s.validateResourcesForUser(ar.RemoteUser, resources)
 		if err != nil {
-			log.Printf("Error validating resources: %v", err)
-			writeTokenEndpointError(w, http.StatusBadRequest, "invalid_request", "invalid resource")
+			//log.Printf("Error validating resources: %v", err)
+			writeTokenEndpointError(w, http.StatusBadRequest, "invalid_request", err.Error())
 			return
 		}
 
@@ -320,8 +319,8 @@ func (s *IDPServer) serveTokenExchange(w http.ResponseWriter, r *http.Request) {
 	who := ar.RemoteUser
 	rules, err := tailcfg.UnmarshalCapJSON[stsCapRule](who.CapMap, "test-tailscale.com/idp/sts/openly-allow")
 	if err != nil {
-		log.Printf("tsidp: failed to unmarshal STS capability: %v", err)
-		writeTokenEndpointError(w, http.StatusForbidden, "access_denied", "access denied")
+		//log.Printf("tsidp: failed to unmarshal STS capability: %v", err)
+		writeTokenEndpointError(w, http.StatusForbidden, "access_denied", fmt.Sprintf("failed to unmarshal STS capability: %s", err.Error()))
 		return
 	}
 
@@ -454,8 +453,8 @@ func (s *IDPServer) serveTokenExchange(w http.ResponseWriter, r *http.Request) {
 func (s *IDPServer) issueTokens(w http.ResponseWriter, ar *AuthRequest) {
 	signer, err := s.oidcSigner()
 	if err != nil {
-		log.Printf("Error getting signer: %v", err)
-		writeTokenEndpointError(w, http.StatusInternalServerError, "server_error", "internal server error")
+		//log.Printf("Error getting signer: %v", err)
+		writeTokenEndpointError(w, http.StatusInternalServerError, "server_error", "internal server error - could not get signer")
 		return
 	}
 	jti := rands.HexString(32)
@@ -538,14 +537,14 @@ func (s *IDPServer) issueTokens(w http.ResponseWriter, ar *AuthRequest) {
 
 	rules, err := tailcfg.UnmarshalCapJSON[capRule](who.CapMap, tailcfg.PeerCapabilityTsIDP)
 	if err != nil {
-		log.Printf("tsidp: failed to unmarshal capability: %v", err)
+		//log.Printf("tsidp: failed to unmarshal capability: %v", err)
 		writeTokenEndpointError(w, http.StatusBadRequest, "invalid_request", "failed to unmarshal capability")
 		return
 	}
 
 	tsClaimsWithExtra, err := withExtraClaims(tsClaims, rules)
 	if err != nil {
-		log.Printf("tsidp: failed to merge extra claims: %v", err)
+		//log.Printf("tsidp: failed to merge extra claims: %v", err)
 		writeTokenEndpointError(w, http.StatusBadRequest, "invalid_request", "failed to merge extra claims")
 		return
 	}
@@ -558,8 +557,8 @@ func (s *IDPServer) issueTokens(w http.ResponseWriter, ar *AuthRequest) {
 	// Create an OIDC token using this issuer's signer.
 	token, err := jwt.Signed(signer).Claims(tsClaimsWithExtra).CompactSerialize()
 	if err != nil {
-		log.Printf("Error getting token: %v", err)
-		writeTokenEndpointError(w, http.StatusInternalServerError, "server_error", "internal server error")
+		//log.Printf("Error getting token: %v", err)
+		writeTokenEndpointError(w, http.StatusInternalServerError, "server_error", "error creating token")
 		return
 	}
 
@@ -733,6 +732,7 @@ func writeTokenEndpointError(w http.ResponseWriter, statusCode int, errorCode, e
 	w.Header().Set("Cache-Control", "no-store")
 	w.Header().Set("Pragma", "no-cache")
 	w.WriteHeader(statusCode)
+	//log.Printf("XXX token endpoint error: %d > %s\n", statusCode, errorDescription)
 	json.NewEncoder(w).Encode(oauthErrorResponse{
 		Error:            errorCode,
 		ErrorDescription: errorDescription,
@@ -872,16 +872,16 @@ func (s *IDPServer) serveIntrospect(w http.ResponseWriter, r *http.Request) {
 
 // allowRelyingParty checks if the relying party is allowed to access the token
 // Migrated from legacy/tsidp.go:520-552
-func (ar *AuthRequest) allowRelyingParty(r *http.Request, lc *local.Client) error {
+func (ar *AuthRequest) allowRelyingParty(r *http.Request, lc *local.Client) (int, error) {
 	if ar.LocalRP {
 		ra, err := netip.ParseAddrPort(r.RemoteAddr)
 		if err != nil {
-			return err
+			return http.StatusBadRequest, err
 		}
 		if !ra.Addr().IsLoopback() {
-			return fmt.Errorf("tsidp: request from non-loopback address")
+			return http.StatusForbidden, fmt.Errorf("tsidp: request from non-loopback address")
 		}
-		return nil
+		return http.StatusOK, nil
 	}
 	if ar.FunnelRP != nil {
 		clientID, clientSecret, ok := r.BasicAuth()
@@ -889,22 +889,30 @@ func (ar *AuthRequest) allowRelyingParty(r *http.Request, lc *local.Client) erro
 			clientID = r.FormValue("client_id")
 			clientSecret = r.FormValue("client_secret")
 		}
+
+		if clientID == "" || clientSecret == "" {
+			return http.StatusUnauthorized, fmt.Errorf("tsidp: missing client credentials")
+		}
+
 		clientIDcmp := subtle.ConstantTimeCompare([]byte(clientID), []byte(ar.FunnelRP.ID))
 		clientSecretcmp := subtle.ConstantTimeCompare([]byte(clientSecret), []byte(ar.FunnelRP.Secret))
-		if clientIDcmp != 1 || clientSecretcmp != 1 {
-			return fmt.Errorf("tsidp: invalid client credentials")
+		if clientIDcmp != 1 {
+			return http.StatusBadRequest, fmt.Errorf("tsidp: client_id mismatch")
 		}
-		return nil
+		if clientSecretcmp != 1 {
+			return http.StatusUnauthorized, fmt.Errorf("tsidp: invalid client secret: [%s] [%s]", clientID, clientSecret)
+		}
+		return http.StatusOK, nil
 	}
 	if lc == nil {
-		return fmt.Errorf("tsidp: no local client available for node validation")
+		return http.StatusInternalServerError, fmt.Errorf("tsidp: no local client available for node validation")
 	}
 	who, err := lc.WhoIs(r.Context(), r.RemoteAddr)
 	if err != nil {
-		return fmt.Errorf("tsidp: error getting WhoIs: %w", err)
+		return http.StatusInternalServerError, fmt.Errorf("tsidp: error getting WhoIs: %w", err)
 	}
 	if ar.RPNodeID != who.Node.ID {
-		return fmt.Errorf("tsidp: token for different node")
+		return http.StatusForbidden, fmt.Errorf("tsidp: token for different node")
 	}
-	return nil
+	return http.StatusOK, nil
 }

--- a/server/token_test.go
+++ b/server/token_test.go
@@ -561,7 +561,7 @@ func TestRefreshTokenFlow(t *testing.T) {
 			refreshToken: "valid-refresh-token",
 			clientID:     "wrong-client",
 			clientSecret: "wrong-secret",
-			expectStatus: http.StatusUnauthorized, // Both legacy and server should reject this
+			expectStatus: http.StatusBadRequest, // Both legacy and server should reject this
 			checkResponse: func(t *testing.T, body []byte) {
 				var resp oauthErrorResponse
 				if err := json.Unmarshal(body, &resp); err != nil {
@@ -1319,6 +1319,235 @@ func TestServeToken(t *testing.T) {
 				}
 				if !reflect.DeepEqual(got, want) {
 					t.Errorf("claim %q: got %v, want %v", k, got, want)
+				}
+			}
+		})
+	}
+}
+
+// TestServeTokenWithClientValidation verifies OAuth token endpoint security
+func TestServeTokenWithClientValidation(t *testing.T) {
+	tests := []struct {
+		name                string
+		method              string
+		grantType           string
+		code                string
+		clientID            string
+		clientSecret        string
+		redirectURI         string
+		useBasicAuth        bool
+		setupAuthRequest    bool
+		authRequestClient   string
+		authRequestRedirect string
+		expectError         bool
+		expectCode          int
+		expectIDToken       bool
+	}{
+		{
+			name:                "valid token exchange with form credentials",
+			method:              "POST",
+			grantType:           "authorization_code",
+			code:                "valid-code",
+			clientID:            "test-client",
+			clientSecret:        "test-secret",
+			redirectURI:         "https://rp.example.com/callback",
+			setupAuthRequest:    true,
+			authRequestClient:   "test-client",
+			authRequestRedirect: "https://rp.example.com/callback",
+			expectIDToken:       true,
+		},
+		{
+			name:                "valid token exchange with basic auth",
+			method:              "POST",
+			grantType:           "authorization_code",
+			code:                "valid-code",
+			redirectURI:         "https://rp.example.com/callback",
+			useBasicAuth:        true,
+			clientID:            "test-client",
+			clientSecret:        "test-secret",
+			setupAuthRequest:    true,
+			authRequestClient:   "test-client",
+			authRequestRedirect: "https://rp.example.com/callback",
+			expectIDToken:       true,
+		},
+		{
+			name:                "missing client credentials",
+			method:              "POST",
+			grantType:           "authorization_code",
+			code:                "valid-code",
+			redirectURI:         "https://rp.example.com/callback",
+			setupAuthRequest:    true,
+			authRequestClient:   "test-client",
+			authRequestRedirect: "https://rp.example.com/callback",
+			expectError:         true,
+			expectCode:          http.StatusUnauthorized,
+		},
+		{
+			name:              "client_id mismatch",
+			method:            "POST",
+			grantType:         "authorization_code",
+			code:              "valid-code",
+			clientID:          "wrong-client",
+			clientSecret:      "test-secret",
+			redirectURI:       "https://rp.example.com/callback",
+			setupAuthRequest:  true,
+			authRequestClient: "test-client",
+			expectError:       true,
+			expectCode:        http.StatusBadRequest,
+		},
+		{
+			name:                "invalid client secret",
+			method:              "POST",
+			grantType:           "authorization_code",
+			code:                "valid-code",
+			clientID:            "test-client",
+			clientSecret:        "wrong-secret",
+			redirectURI:         "https://rp.example.com/callback",
+			setupAuthRequest:    true,
+			authRequestClient:   "test-client",
+			authRequestRedirect: "https://rp.example.com/callback",
+			expectError:         true,
+			expectCode:          http.StatusUnauthorized,
+		},
+		{
+			name:                "redirect_uri mismatch",
+			method:              "POST",
+			grantType:           "authorization_code",
+			code:                "valid-code",
+			clientID:            "test-client",
+			clientSecret:        "test-secret",
+			redirectURI:         "https://wrong.example.com/callback",
+			setupAuthRequest:    true,
+			authRequestClient:   "test-client",
+			authRequestRedirect: "https://rp.example.com/callback",
+			expectError:         true,
+			expectCode:          http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := setupTestServer(t, nil)
+
+			// Setup authorization request if needed
+			if tt.setupAuthRequest {
+				now := time.Now()
+				profile := &tailcfg.UserProfile{
+					LoginName:     "alice@example.com",
+					DisplayName:   "Alice Example",
+					ProfilePicURL: "https://example.com/alice.jpg",
+				}
+				node := &tailcfg.Node{
+					ID:       123,
+					Name:     "test-node.test.ts.net.",
+					User:     456,
+					Key:      key.NodePublic{},
+					Cap:      1,
+					DiscoKey: key.DiscoPublic{},
+				}
+				remoteUser := &apitype.WhoIsResponse{
+					Node:        node,
+					UserProfile: profile,
+					CapMap:      tailcfg.PeerCapMap{},
+				}
+
+				var funnelClientPtr *FunnelClient
+				if tt.authRequestClient != "" {
+					funnelClientPtr = &FunnelClient{
+						ID:          tt.authRequestClient,
+						Secret:      "test-secret",
+						Name:        "Test Client",
+						RedirectURI: tt.authRequestRedirect,
+					}
+					srv.funnelClients[tt.authRequestClient] = funnelClientPtr
+				}
+
+				srv.code["valid-code"] = &AuthRequest{
+					ClientID:    tt.authRequestClient,
+					Nonce:       "nonce123",
+					RedirectURI: tt.authRequestRedirect,
+					ValidTill:   now.Add(5 * time.Minute),
+					RemoteUser:  remoteUser,
+					LocalRP:     false,
+					FunnelRP:    funnelClientPtr,
+				}
+			}
+
+			// Create form data
+			form := url.Values{}
+			form.Set("grant_type", tt.grantType)
+			form.Set("code", tt.code)
+			form.Set("redirect_uri", tt.redirectURI)
+
+			if !tt.useBasicAuth {
+				if tt.clientID != "" {
+					form.Set("client_id", tt.clientID)
+				}
+				if tt.clientSecret != "" {
+					form.Set("client_secret", tt.clientSecret)
+				}
+			}
+
+			req := httptest.NewRequest(tt.method, "/token", strings.NewReader(form.Encode()))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			req.RemoteAddr = "127.0.0.1:12345"
+
+			if tt.useBasicAuth && tt.clientID != "" && tt.clientSecret != "" {
+				req.SetBasicAuth(tt.clientID, tt.clientSecret)
+			}
+
+			rr := httptest.NewRecorder()
+			srv.serveToken(rr, req)
+
+			if tt.expectError {
+				if rr.Code != tt.expectCode {
+					t.Errorf("expected status code %d, got %d: %s", tt.expectCode, rr.Code, rr.Body.String())
+				}
+			} else if tt.expectIDToken {
+				if rr.Code != http.StatusOK {
+					t.Errorf("expected 200 OK, got %d: %s", rr.Code, rr.Body.String())
+				}
+
+				var resp struct {
+					IDToken     string `json:"id_token"`
+					AccessToken string `json:"access_token"`
+					TokenType   string `json:"token_type"`
+					ExpiresIn   int    `json:"expires_in"`
+				}
+
+				if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+					t.Fatalf("failed to unmarshal response: %v", err)
+				}
+
+				if resp.IDToken == "" {
+					t.Error("expected id_token in response")
+				}
+				if resp.AccessToken == "" {
+					t.Error("expected access_token in response")
+				}
+				if resp.TokenType != "Bearer" {
+					t.Errorf("expected token_type 'Bearer', got '%s'", resp.TokenType)
+				}
+				if resp.ExpiresIn != 300 {
+					t.Errorf("expected expires_in 300, got %d", resp.ExpiresIn)
+				}
+
+				// Verify access token was stored
+				srv.mu.Lock()
+				_, ok := srv.accessToken[resp.AccessToken]
+				srv.mu.Unlock()
+
+				if !ok {
+					t.Error("expected access token to be stored")
+				}
+
+				// Verify authorization code was consumed
+				srv.mu.Lock()
+				_, ok = srv.code[tt.code]
+				srv.mu.Unlock()
+
+				if ok {
+					t.Error("expected authorization code to be consumed")
 				}
 			}
 		})

--- a/server/token_test.go
+++ b/server/token_test.go
@@ -353,7 +353,6 @@ func TestIntrospectWithResources(t *testing.T) {
 func TestIntrospectionRFC7662Compliance(t *testing.T) {
 	s := &IDPServer{
 		serverURL:     "https://idp.test.ts.net",
-		loopbackURL:   "http://localhost:8080",
 		accessToken:   make(map[string]*AuthRequest),
 		funnelClients: make(map[string]*FunnelClient),
 	}
@@ -1133,16 +1132,19 @@ func TestAZPClaimWithMultipleAudiences(t *testing.T) {
 // - renamed authRequest -> AuthRequest
 func TestServeToken(t *testing.T) {
 	tests := []struct {
-		name        string
-		caps        tailcfg.PeerCapMap
-		method      string
-		grantType   string
-		code        string
-		omitCode    bool
-		redirectURI string
-		remoteAddr  string
-		expectError bool
-		expected    map[string]any
+		name           string
+		caps           tailcfg.PeerCapMap
+		method         string
+		grantType      string
+		code           string
+		omitCode       bool
+		redirectURI    string
+		remoteAddr     string
+		expectError    bool
+		expected       map[string]any
+		clientID       string
+		clientSecret   string
+		useCredentials bool
 	}{
 		{
 			name:        "GET not allowed",
@@ -1189,12 +1191,15 @@ func TestServeToken(t *testing.T) {
 			expectError: true,
 		},
 		{
-			name:        "extra claim included",
-			method:      "POST",
-			grantType:   "authorization_code",
-			redirectURI: "https://rp.example.com/callback",
-			code:        "valid-code",
-			remoteAddr:  "127.0.0.1:12345",
+			name:           "extra claim included",
+			method:         "POST",
+			grantType:      "authorization_code",
+			redirectURI:    "https://rp.example.com/callback",
+			code:           "extra-claim-included",
+			remoteAddr:     "127.0.0.1:12345",
+			clientID:       "test-client",
+			clientSecret:   "test-secret",
+			useCredentials: true,
 			caps: tailcfg.PeerCapMap{
 				tailcfg.PeerCapabilityTsIDP: {
 					mustMarshalJSON(t, capRule{
@@ -1257,12 +1262,27 @@ func TestServeToken(t *testing.T) {
 			s := &IDPServer{
 				code: map[string]*AuthRequest{
 					"valid-code": {
-						ClientID:    "client-id",
+						ClientID:    "test-client",
 						Nonce:       "nonce123",
 						RedirectURI: "https://rp.example.com/callback",
 						ValidTill:   now.Add(5 * time.Minute),
 						RemoteUser:  remoteUser,
-						LocalRP:     true,
+					},
+
+					// only for the extra claim included test
+					// which requires checking a client_id and client_secret
+					"extra-claim-included": {
+						ClientID:    "test-client",
+						Nonce:       "nonce123",
+						RedirectURI: "https://rp.example.com/callback",
+						ValidTill:   now.Add(5 * time.Minute),
+						RemoteUser:  remoteUser,
+						FunnelRP: &FunnelClient{
+							Name:         "A Test Client",
+							ID:           "test-client",
+							Secret:       "test-secret",
+							RedirectURIs: []string{"https://rp.example.com"},
+						},
 					},
 				},
 			}
@@ -1274,6 +1294,12 @@ func TestServeToken(t *testing.T) {
 			form.Set("redirect_uri", tt.redirectURI)
 			if !tt.omitCode {
 				form.Set("code", tt.code)
+			}
+
+			if tt.useCredentials {
+				t.Log("Sending credentials") // Debug log"
+				form.Set("client_id", tt.clientID)
+				form.Set("client_secret", tt.clientSecret)
 			}
 
 			req := httptest.NewRequest(tt.method, "/token", strings.NewReader(form.Encode()))
@@ -1468,7 +1494,6 @@ func TestServeTokenWithClientValidation(t *testing.T) {
 					RedirectURI: tt.authRequestRedirect,
 					ValidTill:   now.Add(5 * time.Minute),
 					RemoteUser:  remoteUser,
-					LocalRP:     false,
 					FunnelRP:    funnelClientPtr,
 				}
 			}


### PR DESCRIPTION
This PR updates `serveAuthorize` to require a `client_id` and `client_secret` credentials. Credentials can be obtained in two ways: 

- created in the UI and pre-shared
- through dynamic client registration (DCR) at the `/register` endpoint. 

The special authentication logic for relaying parties from localhost have also been replaced. All relaying parties, regardless of source, are expected to provide a valid client_id and client_secret. 

Fixes #8 