### PR TITLE
server: fix sts oauth flow

### DIFF
--- a/cmd/verifier/verifier.go
+++ b/cmd/verifier/verifier.go
@@ -36,6 +36,16 @@ type ProviderMetadata struct {
 	IntrospectionEndpoint string `json:"introspection_endpoint"`
 }
 
+// STSTokenResponse holds the response from a token exchange request.
+type STSTokenResponse struct {
+	AccessToken     string `json:"access_token"`
+	IssuedTokenType string `json:"issued_token_type"`
+	TokenType       string `json:"token_type"`
+	ExpiresIn       int    `json:"expires_in"`
+	Scope           string `json:"scope,omitempty"`
+	RefreshToken    string `json:"refresh_token,omitempty"`
+}
+
 // ClientCredentials holds the client_id and client_secret after dynamic registration.
 type ClientCredentials struct {
 	ClientID     string `json:"client_id"`
@@ -114,6 +124,9 @@ type JSONWebKeySet struct {
 var (
 	// issuerURL is now set via a command-line flag.
 	issuerURL string
+	
+	// stsEnabled determines if STS token exchange should be performed
+	stsEnabled bool
 
 	// The local address our application will run on to handle the redirect.
 	redirectHost = "http://127.0.0.1:8080"
@@ -133,6 +146,7 @@ var (
 func main() {
 	// Setup and parse the -idp flag for the issuer URL.
 	flag.StringVar(&issuerURL, "idp", "", "The issuer URL of the OpenID Connect provider (e.g., https://accounts.google.com)")
+	flag.BoolVar(&stsEnabled, "sts", false, "Enable STS token exchange using urn:ietf:params:oauth:grant-type:token-exchange")
 	flag.Parse()
 	if issuerURL == "" {
 		fmt.Println("Error: The -idp flag is required. Please provide the issuer URL of your OIDC provider.")
@@ -305,6 +319,19 @@ func main() {
 		os.Exit(1)
 	}
 	fmt.Printf("✅ Success. UserInfo response received.\n")
+
+	// Step 8: Perform STS token exchange if -sts flag is enabled
+	if stsEnabled {
+		fmt.Println("\nStep 8: Performing STS token exchange...")
+		stsToken, err := performTokenExchange(ctx, tokens.AccessToken)
+		if err != nil {
+			fmt.Printf("❌ Error performing token exchange: %v\n", err)
+		} else {
+			fmt.Printf("✅ Success. Received exchanged token: %s...\n", stsToken.AccessToken[:20])
+			fmt.Println("\n--- STS Token Exchange Response ---")
+			fmt.Println(prettyPrint(stsToken))
+		}
+	}
 
 	// Display final results to the console
 	fmt.Println("\n---------------------- OIDC FLOW COMPLETE ----------------------")
@@ -643,4 +670,39 @@ func prettyPrintJSON(jsonStr string) string {
 		return jsonStr // Not valid JSON, return as is
 	}
 	return prettyPrint(v)
+}
+
+// performTokenExchange performs an OAuth 2.0 Token Exchange as per RFC 8693.
+func performTokenExchange(ctx context.Context, subjectToken string) (*STSTokenResponse, error) {
+	params := url.Values{}
+	params.Add("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
+	params.Add("subject_token", subjectToken)
+	params.Add("subject_token_type", "urn:ietf:params:oauth:token-type:access_token")
+	params.Add("requested_token_type", "urn:ietf:params:oauth:token-type:access_token")
+	params.Add("audience", clientCreds.ClientID)
+	params.Add("client_id", clientCreds.ClientID)
+	params.Add("client_secret", clientCreds.ClientSecret)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", providerMetadata.TokenEndpoint, strings.NewReader(params.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("token exchange failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var stsResponse STSTokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&stsResponse); err != nil {
+		return nil, err
+	}
+	return &stsResponse, nil
 }

--- a/cmd/verifier/verifier.go
+++ b/cmd/verifier/verifier.go
@@ -124,7 +124,7 @@ type JSONWebKeySet struct {
 var (
 	// issuerURL is now set via a command-line flag.
 	issuerURL string
-	
+
 	// stsEnabled determines if STS token exchange should be performed
 	stsEnabled bool
 
@@ -682,6 +682,7 @@ func performTokenExchange(ctx context.Context, subjectToken string) (*STSTokenRe
 	params.Add("audience", clientCreds.ClientID)
 	params.Add("client_id", clientCreds.ClientID)
 	params.Add("client_secret", clientCreds.ClientSecret)
+	params.Add("scope", "openid profile")
 
 	req, err := http.NewRequestWithContext(ctx, "POST", providerMetadata.TokenEndpoint, strings.NewReader(params.Encode()))
 	if err != nil {
@@ -704,5 +705,29 @@ func performTokenExchange(ctx context.Context, subjectToken string) (*STSTokenRe
 	if err := json.NewDecoder(resp.Body).Decode(&stsResponse); err != nil {
 		return nil, err
 	}
+
+	// Validate that the returned token has the required scopes
+	if !validateScopes(stsResponse.Scope, []string{"openid", "email", "profile"}) {
+		return nil, fmt.Errorf("token exchange returned insufficient scopes: got %s", stsResponse.Scope)
+	}
+
 	return &stsResponse, nil
+}
+
+// Helper function to validate scopes
+func validateScopes(returnedScope string, requiredScopes []string) bool {
+	returnedScopes := strings.Fields(returnedScope)
+	for _, required := range requiredScopes {
+		found := false
+		for _, returned := range returnedScopes {
+			if returned == required {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
 }

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -144,7 +144,7 @@ func TestServeDynamicClientRegistration(t *testing.T) {
 				if _, ok := rawResp["client_secret"]; !ok {
 					t.Error("expected 'client_secret' field in response, not found")
 				}
-				if _, ok := rawResp["name"]; !ok {
+				if _, ok := rawResp["client_name"]; !ok {
 					t.Error("expected 'name' field in response, not found")
 				}
 				if _, ok := rawResp["redirect_uris"]; !ok {
@@ -158,7 +158,7 @@ func TestServeDynamicClientRegistration(t *testing.T) {
 				if clientSecret, ok := rawResp["client_secret"].(string); !ok || clientSecret == "" {
 					t.Error("client_secret should be a non-empty string")
 				}
-				if clientName, ok := rawResp["name"].(string); !ok || clientName != "Test Client" {
+				if clientName, ok := rawResp["client_name"].(string); !ok || clientName != "Test Client" {
 					t.Errorf("expected name to be 'Test Client', got %v", rawResp["name"])
 				}
 			},

--- a/server/clients.go
+++ b/server/clients.go
@@ -22,7 +22,7 @@ import (
 type FunnelClient struct {
 	ID                      string    `json:"client_id"`
 	Secret                  string    `json:"client_secret,omitempty"`
-	Name                    string    `json:"name,omitempty"`
+	Name                    string    `json:"client_name,omitempty"`
 	RedirectURIs            []string  `json:"redirect_uris"`
 	TokenEndpointAuthMethod string    `json:"token_endpoint_auth_method,omitempty"`
 	GrantTypes              []string  `json:"grant_types,omitempty"`

--- a/server/token.go
+++ b/server/token.go
@@ -467,6 +467,8 @@ func (s *IDPServer) serveTokenExchange(w http.ResponseWriter, r *http.Request) {
 		ActorInfo:        actorInfo,
 
 		// Preserve original RP context
+		LocalRP:  ar.LocalRP,
+		RPNodeID: ar.RPNodeID,
 		FunnelRP: ar.FunnelRP, // Keep original funnel client if it exists
 	}
 

--- a/tsidp-server.go
+++ b/tsidp-server.go
@@ -235,6 +235,16 @@ func debugPrintRequest(next http.Handler) http.Handler {
 		fmt.Printf("[DEBUG REQUEST] RemoteAddr: %s\n", r.RemoteAddr)
 		fmt.Printf("[DEBUG REQUEST] User-Agent: %s\n", r.UserAgent())
 
+		// Print query parameters
+		if len(r.URL.Query()) > 0 {
+			fmt.Printf("[DEBUG REQUEST] Query Parameters:\n")
+			for name, values := range r.URL.Query() {
+				for _, value := range values {
+					fmt.Printf("[DEBUG REQUEST]   %s: %s\n", name, value)
+				}
+			}
+		}
+
 		// Print request headers
 		fmt.Printf("[DEBUG REQUEST] Headers:\n")
 		for name, values := range r.Header {

--- a/tsidp-server.go
+++ b/tsidp-server.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -221,13 +222,20 @@ func main() {
 
 func debugPrintRequest(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Read and store the request body
+		var requestBody []byte
+		if r.Body != nil {
+			requestBody, _ = io.ReadAll(r.Body)
+			r.Body = io.NopCloser(bytes.NewBuffer(requestBody)) // Restore body for downstream handlers
+		}
+
 		// Print request details
 		fmt.Printf("[DEBUG REQUEST] %s %s %s\n", r.Method, r.URL.Path, r.Proto)
 		fmt.Printf("[DEBUG REQUEST] Host: %s\n", r.Host)
 		fmt.Printf("[DEBUG REQUEST] RemoteAddr: %s\n", r.RemoteAddr)
 		fmt.Printf("[DEBUG REQUEST] User-Agent: %s\n", r.UserAgent())
 
-		// Print headers (optional - can be commented out if too verbose)
+		// Print request headers
 		fmt.Printf("[DEBUG REQUEST] Headers:\n")
 		for name, values := range r.Header {
 			for _, value := range values {
@@ -235,16 +243,44 @@ func debugPrintRequest(next http.Handler) http.Handler {
 			}
 		}
 
+		// Print request body if present
+		if len(requestBody) > 0 {
+			fmt.Printf("[DEBUG REQUEST] Body:\n%s\n", string(requestBody))
+		} else {
+			fmt.Printf("[DEBUG REQUEST] Body: (empty)\n")
+		}
+
 		fmt.Println("[DEBUG REQUEST] ---")
 
-		// Create a custom ResponseWriter to capture the status code
-		rw := &responseWrapper{ResponseWriter: w}
+		// Create a custom ResponseWriter to capture status code and body
+		rw := &responseWrapper{
+			ResponseWriter: w,
+			statusCode:     200, // Default status code
+			body:           &bytes.Buffer{},
+		}
 
 		// Call the next handler
 		next.ServeHTTP(rw, r)
 
 		// Print response status code
 		fmt.Printf("[DEBUG RESPONSE] Status: %d %s\n", rw.statusCode, http.StatusText(rw.statusCode))
+
+		// Print response headers (captured from the original ResponseWriter)
+		fmt.Printf("[DEBUG RESPONSE] Headers:\n")
+		for name, values := range w.Header() {
+			for _, value := range values {
+				fmt.Printf("[DEBUG RESPONSE]   %s: %s\n", name, value)
+			}
+		}
+
+		// Print response body
+		responseBody := rw.body.Bytes()
+		if len(responseBody) > 0 {
+			fmt.Printf("[DEBUG RESPONSE] Body:\n%s\n", string(responseBody))
+		} else {
+			fmt.Printf("[DEBUG RESPONSE] Body: (empty)\n")
+		}
+
 		fmt.Println("[DEBUG RESPONSE] ---")
 	})
 }
@@ -252,9 +288,20 @@ func debugPrintRequest(next http.Handler) http.Handler {
 type responseWrapper struct {
 	http.ResponseWriter
 	statusCode int
+	body       *bytes.Buffer
 }
 
 func (rw *responseWrapper) WriteHeader(code int) {
 	rw.statusCode = code
 	rw.ResponseWriter.WriteHeader(code)
+}
+
+func (rw *responseWrapper) Write(b []byte) (int, error) {
+	// Capture the response body
+	if rw.body != nil {
+		rw.body.Write(b)
+	}
+
+	// Write to the original response writer
+	return rw.ResponseWriter.Write(b)
 }


### PR DESCRIPTION
In the original migration to the new structure the /authorize endpoint did not properly parse, add and validate the scopes sent in the request. This commit puts that back and adds code in cmd/verifier to ensure responses are correct.