### PR TITLE
cmd/verifier: add PKCE (RFC7636)

### DIFF
--- a/cmd/verifier/README.md
+++ b/cmd/verifier/README.md
@@ -6,6 +6,33 @@ The verifier is meant to be run like so:
 $ go run . -sts -idp https://idp.ts0000.ts.net
 ```
 
+## Testing Security Token Server (sts) RFC 8693
+
+To test the Security Token Server in tsidp make sure an [application grant](https://tailscale.com/kb/1324/grants) has been set.
+
+> [!NOTE]
+> This is a very permissive grant. Recommended only for testing and development:
+
+```
+...
+"grants": [
+  {
+    "src": ["*"],
+    "dst": ["*"],
+    "ip":  ["*"],
+
+    "app": {
+      "tailscale.com/cap/tsidp": [
+        {
+          "users":     ["*"],
+          "resources": ["*"],
+        },
+      ],
+    },
+  },
+...
+```
+
 ## Output Example
 
 ```
@@ -38,6 +65,9 @@ Step 6: Introspecting the access token...
 Step 7: Calling userinfo endpoint...
 ✅ Success. UserInfo response received.
 
+Step 8: Performing STS token exchange...
+✅ Success. Received exchanged token: d7caca739d794734067d...
+
 ---------------------- OIDC FLOW COMPLETE ----------------------
 
 ✅ All steps completed successfully!
@@ -49,7 +79,7 @@ Step 7: Calling userinfo endpoint...
 --- ID Token Claims ---
 {
   "iss": "https://idp.ts001.ts.net",
-  "sub": "userid:7743467757367193",
+  "sub": "userid:0001",
   "aud": [
     "bb136f58ee4838e95c93c0aaf92712e0"
   ],

--- a/cmd/verifier/README.md
+++ b/cmd/verifier/README.md
@@ -3,7 +3,7 @@
 The verifier is meant to be run like so:
 
 ```
-$ go run . -idp https://idp.ts0000.ts.net
+$ go run . -sts -idp https://idp.ts0000.ts.net
 ```
 
 ## Output Example

--- a/cmd/verifier/verifier.go
+++ b/cmd/verifier/verifier.go
@@ -20,6 +20,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"tailscale.com/util/rands"
 )
 
 // --- Structs for Manual JSON Parsing ---
@@ -192,11 +194,7 @@ func main() {
 	}
 
 	// Generate PKCE parameters (RFC 7636)
-	codeVerifier, err = generateCodeVerifier()
-	if err != nil {
-		fmt.Printf("Failed to generate code verifier: %v", err)
-		os.Exit(1)
-	}
+	codeVerifier = rands.HexString(64)
 	codeChallenge = generateCodeChallenge(codeVerifier)
 	fmt.Printf("Generated PKCE parameters: code_verifier=%s..., code_challenge=%s...\n", codeVerifier[:20], codeChallenge[:20])
 
@@ -672,18 +670,6 @@ func generateRandomString(n int) (string, error) {
 		return "", err
 	}
 	return base64.URLEncoding.EncodeToString(b), nil
-}
-
-// generateCodeVerifier generates a PKCE code verifier as per RFC 7636.
-// It must be between 43 and 128 characters long.
-func generateCodeVerifier() (string, error) {
-	b := make([]byte, 32) // 32 bytes = 256 bits
-	_, err := rand.Read(b)
-	if err != nil {
-		return "", err
-	}
-	// Use RawURLEncoding to avoid padding
-	return base64.RawURLEncoding.EncodeToString(b), nil
 }
 
 // generateCodeChallenge generates a PKCE code challenge using S256 method.

--- a/cmd/verifier/verifier.go
+++ b/cmd/verifier/verifier.go
@@ -139,6 +139,10 @@ var (
 	// Nonce and State are used to prevent CSRF and replay attacks.
 	lastState string
 	lastNonce string
+
+	// PKCE parameters for RFC 7636
+	codeVerifier  string
+	codeChallenge string
 )
 
 // --- Main Application Logic ---
@@ -187,6 +191,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Generate PKCE parameters (RFC 7636)
+	codeVerifier, err = generateCodeVerifier()
+	if err != nil {
+		fmt.Printf("Failed to generate code verifier: %v", err)
+		os.Exit(1)
+	}
+	codeChallenge = generateCodeChallenge(codeVerifier)
+	fmt.Printf("Generated PKCE parameters: code_verifier=%s..., code_challenge=%s...\n", codeVerifier[:20], codeChallenge[:20])
+
 	authURL, err := url.Parse(providerMetadata.AuthorizationEndpoint)
 	if err != nil {
 		fmt.Printf("Invalid authorization endpoint URL: %v", err)
@@ -200,10 +213,13 @@ func main() {
 	params.Add("redirect_uri", redirectURI)
 	params.Add("state", lastState)
 	params.Add("nonce", lastNonce)
+	// Add PKCE parameters
+	params.Add("code_challenge", codeChallenge)
+	params.Add("code_challenge_method", "S256")
 	authURL.RawQuery = params.Encode()
 	finalAuthURL := authURL.String()
 
-	fmt.Printf("Generated Authorization URL with state=%s and nonce=%s\n", lastState, lastNonce)
+	fmt.Printf("Generated Authorization URL with state=%s, nonce=%s, and PKCE\n", lastState, lastNonce)
 	fmt.Println("\nAttempting to GET the authorization URL directly...")
 
 	// Create a client that does not follow redirects automatically.
@@ -423,6 +439,8 @@ func exchangeCodeForTokens(ctx context.Context, code string) (*TokenResponse, er
 	params.Add("redirect_uri", redirectURI)
 	params.Add("client_id", clientCreds.ClientID)
 	params.Add("client_secret", clientCreds.ClientSecret)
+	// Add PKCE code_verifier
+	params.Add("code_verifier", codeVerifier)
 
 	req, err := http.NewRequestWithContext(ctx, "POST", providerMetadata.TokenEndpoint, strings.NewReader(params.Encode()))
 	if err != nil {
@@ -654,6 +672,25 @@ func generateRandomString(n int) (string, error) {
 		return "", err
 	}
 	return base64.URLEncoding.EncodeToString(b), nil
+}
+
+// generateCodeVerifier generates a PKCE code verifier as per RFC 7636.
+// It must be between 43 and 128 characters long.
+func generateCodeVerifier() (string, error) {
+	b := make([]byte, 32) // 32 bytes = 256 bits
+	_, err := rand.Read(b)
+	if err != nil {
+		return "", err
+	}
+	// Use RawURLEncoding to avoid padding
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// generateCodeChallenge generates a PKCE code challenge using S256 method.
+func generateCodeChallenge(verifier string) string {
+	h := sha256.New()
+	h.Write([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(h.Sum(nil))
 }
 
 func prettyPrint(v interface{}) string {


### PR DESCRIPTION
Add PKCE code_verifier and code_challenge to the authorization and token exchange steps. These are optional in OAuth 2.0 but required in OAuth 2.1 (required by MCP) so we should test them by default.