### PR TITLE
license_test.go: add test for license headers in .go files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build-linux:
 	GOOS=linux GOARCH=amd64 go build -o build/tsidp-server-linux-amd64-$(shell date +%Y-%m-%d)-$(shell git rev-parse --short=5 HEAD) ./tsidp-server.go
 
 test:
-	go test -count 1 ./server
+	go test -count 1  . ./server
 
 clean:
 	rm -f build/tsidp-server*

--- a/cmd/verifier/verifier.go
+++ b/cmd/verifier/verifier.go
@@ -1,3 +1,6 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
 package main
 
 import (

--- a/license_test.go
+++ b/license_test.go
@@ -1,0 +1,102 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"tailscale.com/util/set"
+)
+
+func normalizeLineEndings(b []byte) []byte {
+	return bytes.ReplaceAll(b, []byte("\r\n"), []byte("\n"))
+}
+
+// TestLicenseHeaders checks that all Go files in the tree
+// directory tree have a correct-looking Tailscale license header.
+func TestLicenseHeaders(t *testing.T) {
+	want := normalizeLineEndings([]byte(strings.TrimLeft(`
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+`, "\n")))
+
+	exceptions := set.Of(
+		// Subprocess test harness code
+		"examples/mcp-server/mcp-server.go",
+	)
+
+	err := filepath.Walk(".", func(path string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf("path %s: %v", path, err)
+		}
+		if exceptions.Contains(filepath.ToSlash(path)) {
+			return nil
+		}
+		base := filepath.Base(path)
+		switch base {
+		case ".git", "node_modules", "tempfork":
+			return filepath.SkipDir
+		}
+		switch base {
+		case "zsyscall_windows.go":
+			// Generated code.
+			return nil
+		}
+
+		if strings.HasSuffix(base, ".config.ts") {
+			return nil
+		}
+		if strings.HasSuffix(base, "_string.go") {
+			// Generated file from go:generate stringer
+			return nil
+		}
+
+		ext := filepath.Ext(base)
+		switch ext {
+		default:
+			return nil
+		case ".go", ".ts", ".tsx":
+		}
+
+		buf := make([]byte, 512)
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		if n, err := io.ReadAtLeast(f, buf, 512); err != nil && err != io.ErrUnexpectedEOF {
+			return err
+		} else {
+			buf = buf[:n]
+		}
+
+		buf = normalizeLineEndings(buf)
+
+		bufNoTrunc := buf
+		if i := bytes.Index(buf, []byte("\npackage ")); i != -1 {
+			buf = buf[:i]
+		}
+
+		if bytes.Contains(buf, want) {
+			return nil
+		}
+
+		if bytes.Contains(bufNoTrunc, []byte("BSD-3-Clause\npackage ")) {
+			t.Errorf("file %s has license header as a package doc; add a blank line before the package line", path)
+			return nil
+		}
+
+		t.Errorf("file %s is missing Tailscale copyright header:\n\n%s", path, want)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+}


### PR DESCRIPTION
Add a test that .go files that are a part of tsidp include a license header. 

Part of work in #15