### PR TITLE
server: add application capabilities for ui and DCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - A Tailscale network (tailnet) with magicDNS and HTTPS enabled
 - A Tailscale authentication key from your tailnet
 - (Recommended) Docker installed on your system
+- Ability to set an Application capability grant
 
 ## Running tsidp
 
@@ -70,6 +71,36 @@ Visit `https://idp.yourtailnet.ts.net` to confirm the service is running.
 _If you're running tsidp for the first time, you may not be able to access it initially even though it is running. It takes a few minutes for the TLS certificate to generate._
 
 </details>
+
+## Setting an Application Capability Grant
+
+tsidp requires an [Application capability grant](https://tailscale.com/kb/1537/grants-app-capabilities) to allow access to the admin UI and dynamic client registration endpoints.
+
+This is a permissive grant that is suitable only for testing purposes:
+
+```json
+"grants": [
+  {
+    "src": ["*"],
+    "dst": ["*"],
+    "app": {
+      "tailscale.com/cap/tsidp": [
+        {
+          // STS controls
+          "users":     ["*"],
+          "resources": ["*"],
+
+          // allow access to UI
+          "allow_admin_ui": true,
+
+          // allow dynamic client registration
+          "allow_dcr": true,
+        },
+      ],
+    },
+  },
+],
+```
 
 ## Application Configuration Guides
 

--- a/server/appcap.go
+++ b/server/appcap.go
@@ -38,7 +38,9 @@ type accessGrantedRules struct {
 	rules        []capRule // list of rules
 }
 
-// addGrantAccessContext adds a AccessGrantedRules to the request context
+// addGrantAccessContext wraps an http.HandlerFunc and adds a AccessGrantedRules to the
+// *http.Request's context. Handlers that are protected by an Application capability grant
+// can conventiently extract and check the granted capabilities.
 func (s *IDPServer) addGrantAccessContext(handler http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// used only for testing to bypass app cap checks
@@ -61,7 +63,7 @@ func (s *IDPServer) addGrantAccessContext(handler http.HandlerFunc) http.Handler
 			return
 		}
 
-		// accessing from localhost
+		// allow all access when requests are coming from localhost
 		if ap, err := netip.ParseAddrPort(r.RemoteAddr); err == nil {
 			if ap.Addr().IsLoopback() {
 				r = r.WithContext(context.WithValue(r.Context(), appCapCtxKey, &accessGrantedRules{

--- a/server/appcap.go
+++ b/server/appcap.go
@@ -1,0 +1,116 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/netip"
+
+	"tailscale.com/client/tailscale/apitype"
+	"tailscale.com/tailcfg"
+)
+
+// shared key for context values
+var appCapCtxKey = &accessGrantedRules{}
+
+// Capability rule types
+type capRule struct {
+	IncludeInUserInfo bool           `json:"includeInUserInfo"`
+	ExtraClaims       map[string]any `json:"extraClaims,omitempty"` // list of features peer is allowed to edit
+
+	// for sts rules
+	Users     []string `json:"users"`     // list of users allowed to access resources (supports "*" wildcard)
+	Resources []string `json:"resources"` // list of audience/resource URIs the user can access
+
+	// allow lists
+	AllowAdminUI bool `json:"allow_admin_ui"`
+	AllowDCR     bool `json:"allow_dcr"` // dynamic client registration
+}
+
+// AccessGrantedRules holds the access rules from granted Application Capabilities.
+// tsidp uses a deny-all-by-default model, so only the granted capabilities are allowed
+type accessGrantedRules struct {
+	allowAdminUI bool
+	allowDCR     bool
+	rules        []capRule // list of rules
+}
+
+// addGrantAccessContext adds a AccessGrantedRules to the request context
+func (s *IDPServer) addGrantAccessContext(handler http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// used only for testing to bypass app cap checks
+		if s.bypassAppCapCheck {
+			r = r.WithContext(context.WithValue(r.Context(), appCapCtxKey, &accessGrantedRules{
+				allowAdminUI: true,
+				allowDCR:     true,
+				rules:        []capRule{}, // empty rules for testing
+			}))
+			handler(w, r)
+			return
+		}
+
+		// when local.Client is not available send through a default-deny rules
+		if s.lc == nil {
+			r = r.WithContext(context.WithValue(r.Context(), appCapCtxKey, &accessGrantedRules{
+				rules: []capRule{}, // empty rules for testing
+			}))
+			handler(w, r)
+			return
+		}
+
+		// accessing from localhost
+		if ap, err := netip.ParseAddrPort(r.RemoteAddr); err == nil {
+			if ap.Addr().IsLoopback() {
+				r = r.WithContext(context.WithValue(r.Context(), appCapCtxKey, &accessGrantedRules{
+					allowAdminUI: true,
+					allowDCR:     true,
+					rules:        []capRule{},
+				}))
+				handler(w, r)
+				return
+			}
+		}
+
+		// Build the access rules from granted application capabilities
+		accessRules := &accessGrantedRules{}
+
+		var remoteAddr string
+		if s.localTSMode {
+			remoteAddr = r.Header.Get("X-Forwarded-For")
+		} else {
+			remoteAddr = r.RemoteAddr
+		}
+
+		var who *apitype.WhoIsResponse
+		var err error
+
+		who, err = s.lc.WhoIs(r.Context(), remoteAddr)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Error getting WhoIs: %v", err), http.StatusInternalServerError)
+			return
+		}
+
+		rules, err := tailcfg.UnmarshalCapJSON[capRule](who.CapMap, "tailscale.com/cap/tsidp")
+		if err != nil {
+			http.Error(w, fmt.Sprintf("failed unmarshaling app cap rule %s", err.Error()), http.StatusInternalServerError)
+			return
+		}
+		accessRules.rules = rules
+
+		// grant rules are accumulated from all granted rules
+		for _, rule := range rules {
+			if rule.AllowAdminUI {
+				accessRules.allowAdminUI = true
+			}
+			if rule.AllowDCR {
+				accessRules.allowDCR = true
+			}
+		}
+
+		r = r.WithContext(context.WithValue(r.Context(), appCapCtxKey, accessRules))
+		handler(w, r)
+	}
+}

--- a/server/clients.go
+++ b/server/clients.go
@@ -292,6 +292,17 @@ func (s *IDPServer) serveDynamicClientRegistration(w http.ResponseWriter, r *htt
 		return
 	}
 
+	access, ok := r.Context().Value(appCapCtxKey).(*accessGrantedRules)
+	if !ok {
+		writeJSONError(w, http.StatusForbidden, "access_denied", "application capability not found")
+		return
+	}
+
+	if !access.allowDCR {
+		writeJSONError(w, http.StatusForbidden, "access_denied", "application capability not granted")
+		return
+	}
+
 	var registrationRequest struct {
 		RedirectURIs            []string `json:"redirect_uris"`
 		TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method,omitempty"`

--- a/server/helpers_test.go
+++ b/server/helpers_test.go
@@ -122,7 +122,7 @@ func normalizeMap(t *testing.T, m map[string]any) map[string]any {
 
 // marshalCapRules is a helper to convert stsCapRule slice to JSON for testing
 // Migrated from legacy/tsidp_test.go:2653-2661
-func marshalCapRules(rules []stsCapRule) []tailcfg.RawMessage {
+func marshalCapRules(rules []capRule) []tailcfg.RawMessage {
 	// UnmarshalCapJSON expects each rule to be a separate RawMessage
 	var msgs []tailcfg.RawMessage
 	for _, rule := range rules {

--- a/server/token_test.go
+++ b/server/token_test.go
@@ -27,7 +27,7 @@ func TestResourceIndicators(t *testing.T) {
 		name               string
 		authorizationQuery string
 		tokenFormData      url.Values
-		capMapRules        []stsCapRule
+		capMapRules        []capRule
 		expectStatus       int
 		checkResponse      func(t *testing.T, body []byte)
 	}{
@@ -38,7 +38,7 @@ func TestResourceIndicators(t *testing.T) {
 				"grant_type":   {"authorization_code"},
 				"redirect_uri": {"https://example.com/callback"},
 			},
-			capMapRules: []stsCapRule{
+			capMapRules: []capRule{
 				{
 					Users:     []string{"*"},
 					Resources: []string{"https://api.example.com"},
@@ -75,7 +75,7 @@ func TestResourceIndicators(t *testing.T) {
 				"grant_type":   {"authorization_code"},
 				"redirect_uri": {"https://example.com/callback"},
 			},
-			capMapRules: []stsCapRule{
+			capMapRules: []capRule{
 				{
 					Users:     []string{"*"},
 					Resources: []string{"*"}, // Allow all resources
@@ -113,7 +113,7 @@ func TestResourceIndicators(t *testing.T) {
 				"redirect_uri": {"https://example.com/callback"},
 				"resource":     {"https://api.example.com"},
 			},
-			capMapRules: []stsCapRule{
+			capMapRules: []capRule{
 				{
 					Users:     []string{"user@example.com"},
 					Resources: []string{"https://api.example.com"},
@@ -138,7 +138,7 @@ func TestResourceIndicators(t *testing.T) {
 				"redirect_uri": {"https://example.com/callback"},
 				"resource":     {"https://unauthorized.example.com"},
 			},
-			capMapRules: []stsCapRule{
+			capMapRules: []capRule{
 				{
 					Users:     []string{"user@example.com"},
 					Resources: []string{"https://api.example.com"},
@@ -806,7 +806,7 @@ func TestRefreshTokenWithResources(t *testing.T) {
 		name              string
 		originalResources []string
 		refreshResources  []string
-		capMapRules       []stsCapRule
+		capMapRules       []capRule
 		expectStatus      int
 		expectError       string
 	}{
@@ -814,7 +814,7 @@ func TestRefreshTokenWithResources(t *testing.T) {
 			name:              "refresh with resource downscoping",
 			originalResources: []string{"https://api1.example.com", "https://api2.example.com"},
 			refreshResources:  []string{"https://api1.example.com"},
-			capMapRules: []stsCapRule{
+			capMapRules: []capRule{
 				{
 					Users:     []string{"*"},
 					Resources: []string{"*"},
@@ -826,7 +826,7 @@ func TestRefreshTokenWithResources(t *testing.T) {
 			name:              "refresh with resource not in original grant",
 			originalResources: []string{"https://api1.example.com"},
 			refreshResources:  []string{"https://api2.example.com"},
-			capMapRules: []stsCapRule{
+			capMapRules: []capRule{
 				{
 					Users:     []string{"*"},
 					Resources: []string{"*"},
@@ -839,7 +839,7 @@ func TestRefreshTokenWithResources(t *testing.T) {
 			name:              "refresh without resource parameter",
 			originalResources: []string{"https://api1.example.com"},
 			refreshResources:  nil,
-			capMapRules: []stsCapRule{
+			capMapRules: []capRule{
 				{
 					Users:     []string{"*"},
 					Resources: []string{"*"},

--- a/server/ui_test.go
+++ b/server/ui_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestUIDenyOnMissingApplicationGrant(t *testing.T) {
+
+	tests := []struct {
+		name              string
+		bypassAppCapCheck bool
+		expectedStatus    int
+	}{
+		{name: "No UI Application Capability", bypassAppCapCheck: false, expectedStatus: http.StatusForbidden},
+		{name: "Has UI application Capability", bypassAppCapCheck: true, expectedStatus: http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &IDPServer{
+				bypassAppCapCheck: tt.bypassAppCapCheck,
+			}
+			req := httptest.NewRequest("GET", "/", nil)
+			rr := httptest.NewRecorder()
+			s.ServeHTTP(rr, req)
+
+			if rr.Code != tt.expectedStatus {
+				t.Errorf("expected status %d, got %d", tt.expectedStatus, rr.Code)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add new Application capabilities to limit access to the UI and dynamic client registration (DCR) endpoints.

This also unifies the structs used to UnmarshalCapJSON into a single struct with fields for all current uses.

Fixes: #44, #16, #17