### PR TITLE
server: unify and improve logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-osx build-linux test clean
+.PHONY: build build-osx build-linux test clean docker-image
 
 build: build-osx build-linux
 
@@ -9,6 +9,9 @@ build-osx:
 build-linux:
 	@mkdir -p build
 	GOOS=linux GOARCH=amd64 go build -o build/tsidp-server-linux-amd64-$(shell date +%Y-%m-%d)-$(shell git rev-parse --short=5 HEAD) ./tsidp-server.go
+
+docker-image:
+	docker build -t tsidp:latest .
 
 test:
 	go test -count 1  . ./server

--- a/README.md
+++ b/README.md
@@ -18,38 +18,49 @@
 
 ### (Recommended) Using the pre-built image
 
-To be updated.
-
-### Other ways to build & run tsidp
-
-<details>
-<summary>Building your own container</summary>
-
-Replace `YOUR_TAILSCALE_AUTHKEY` with your Tailscale authentication key in the following commands:
-
-1. Use an existing auth key or create a new auth key in the [Tailscale dashboard](https://login.tailscale.com/admin/settings/keys). Ensure you select an existing [tag](https://tailscale.com/kb/1068/tags) or create a new one.
+Docker images are automatically published on when releases are tagged.
 
 ```bash
-# Build the container using the included Dockerfile
-docker build -t tsidp .
+# to use the latest image
+$ docker pull ghcr.io/tailscale/tsidp:latest
 
+# to use a specific release version
+$ docker pull ghcr.io/tailscale/tsidp:v0.0.2
+```
+
+Running a tsidp container:
+
+> [!TIP]
+> Replace `YOUR_TAILSCALE_AUTHKEY` with your Tailscale authentication key in the following commands:
+>
+> Use an existing auth key or create a new auth key in the [Tailscale dashboard](https://login.tailscale.com/admin/settings/keys). Ensure you select an existing [tag](https://tailscale.com/kb/1068/tags) or create a new one.
+
+```bash
 # Run tsidp with a persistent volume to store state
 docker run -d \
   --name tsidp \
   -p 443:443 \
   -v tsidp-data:/data \
-  -e TS_STATE_DIR=/data \
-  -e TS_AUTHKEY=YOUR_TAILSCALE_AUTHKEY \
-  -e TSNET_FORCE_LOGIN=1 \
   -e TAILSCALE_USE_WIP_CODE=1 \
-  -e TSIDP_ENABLE_STS=1 \
+  -e TS_STATE_DIR=/data \
   -e TS_HOSTNAME=idp \
-  tsidp
+  -e TSIDP_ENABLE_STS=1 \
+  ghcr.io/tailscale/tsidp:latest
 ```
 
 Visit `https://idp.yourtailnet.ts.net` to confirm the service is running.
 
-_If you're running tsidp for the first time, you may not be able to access it initially even though it is running. It takes a few minutes for the TLS certificate to generate._
+> [!NOTE]
+> If you're running tsidp for the first time it may take a few minutes for the TLS certificate to generate. You may not be able to access the service until the certificate is ready.
+
+### Other Ways to Build and Run
+
+<details>
+<summary>Building your own container</summary>
+
+```bash
+$ make docker-image
+```
 
 </details>
 
@@ -60,26 +71,23 @@ If you'd like to build tsidp and / or run it directly you can do the following:
 
 ```bash
 # Clone the Tailscale repository
-git clone https://github.com/tailscale/tsidp.git
-cd tsidp
+$ git clone https://github.com/tailscale/tsidp.git
+$ cd tsidp
+
+# run with default values for flags
+$ TAILSCALE_USE_WIP_CODE=1 TS_AUTHKEY={YOUR_TAILSCALE_AUTHKEY} TSNET_FORCE_LOGIN=1 go run .
 ```
-
-Replace `YOUR_TAILSCALE_AUTHKEY` with your Tailscale authentication key in the following commands:
-
-1. Use an existing auth key or create a new auth key in the [Tailscale dashboard](https://login.tailscale.com/admin/settings/keys). Ensure you select an existing [tag](https://tailscale.com/kb/1068/tags) or create a new one.
-2. Run `TS_AUTH_KEY=YOUR_TAILSCALE_AUTHKEY TAILSCALE_USE_WIP_CODE=1 TSNET_FORCE_LOGIN=1 go run .`
-
-Visit `https://idp.yourtailnet.ts.net` to confirm the service is running.
-
-_If you're running tsidp for the first time, you may not be able to access it initially even though it is running. It takes a few minutes for the TLS certificate to generate._
 
 </details>
 
 ## Setting an Application Capability Grant
 
-tsidp requires an [Application capability grant](https://tailscale.com/kb/1537/grants-app-capabilities) to allow access to the admin UI and dynamic client registration endpoints.
+> [!IMPORTANT]
+> Access to the admin UI and dynamic client registration endpoints are **denied** by default.
 
-This is a permissive grant that is suitable only for testing purposes:
+To access the admin UI and dynamic client registration endpoints an [Application capability grant](https://tailscale.com/kb/1537/grants-app-capabilities) must be set in the the [Tailscale console](https://login.tailscale.com/admin/acls/).
+
+This is a permissive grant that is suitable for testing purposes:
 
 ```json
 "grants": [
@@ -89,15 +97,15 @@ This is a permissive grant that is suitable only for testing purposes:
     "app": {
       "tailscale.com/cap/tsidp": [
         {
-          // STS controls
-          "users":     ["*"],
-          "resources": ["*"],
-
           // allow access to UI
           "allow_admin_ui": true,
 
           // allow dynamic client registration
           "allow_dcr": true,
+
+          // Secure Token Service (STS) controls
+          "users":     ["*"],
+          "resources": ["*"],
         },
       ],
     },
@@ -105,7 +113,59 @@ This is a permissive grant that is suitable only for testing purposes:
 ],
 ```
 
-## Application Configuration Guides
+## tsidp Configuration Options
+
+The `tsidp-server` is configured by several command-line flags:
+
+| Flag                    | Description                                                                                        | Default  |
+| ----------------------- | -------------------------------------------------------------------------------------------------- | -------- |
+| `-dir <path>`           | Directory path to save tsnet and tsidp state. Recommend to be set.                                 | `""`     |
+| `-hostname <hostname>`  | hostname on tailnet. Will become `<hostname>.your-tailnet.ts.net`                                  | `idp`    |
+| `-port <port>`          | Port to listen on                                                                                  | `443`    |
+| `-local-port <port>`    | Listen on `localhost:<port>`. Useful for testing                                                   | disabled |
+| `-use-local-tailscaled` | Use local tailscaled instead of tsnet                                                              | `false`  |
+| `-funnel`               | Use Tailscale Funnel to make tsidp available on the public internet so it works with SaaS products | disabled |
+| `-enable-sts`           | Enable OAuth token exchange using RFC 8693                                                         | disabled |
+| `-log <level>`          | Set logging level: `debug`, `info`, `warn`, `error`                                                | `info`   |
+| `-debug-all-requests`   | For development. Prints all requests and responses                                                 | disabled |
+| `-debug-tsnet`          | For development. Enables debug level logging with tsnet connection                                 | disabled |
+
+### CLI Environment Variables
+
+The `tsidp-server` binary is configured through the CLI flags above. However, there are several environment variables that configure the libraries `tsidp-server` uses to connect to the Tailnet.
+
+#### Required
+
+- `TAILSCALE_USE_WIP_CODE=1`: required while tsidp is in development (<v1.0.0).
+
+#### Optional
+
+These environment variables are used when tsidp does not have any state information set in `-dir <path>`.
+
+- `TS_AUTHKEY=<key>`: Key for registering a tsidp as a new node on your tailnet. If omitted a link will be printed to manually register.
+- `TSNET_FORCE_LOGIN=1`: Force re-login of the node. Useful during development.
+
+### Docker Environment Variables
+
+The Docker image exposes the CLI flags through environment variables. If omitted the default values for the CLI flags will be used.
+
+> [!NOTE] > `TS_STATE_DIR` and `TS_HOSTNAME` are legacy names. These will be replaced by `TSIDP_STATE_DIR` and `TSIDP_HOSTNAME` in the future.
+
+| Environment Variable                     | CLI flag                   |
+| ---------------------------------------- | -------------------------- |
+| `TS_STATE_DIR=<path>` _\*note prefix_    | `-dir <path>`              |
+| `TS_HOSTNAME=<hostname>` _\*note prefix_ | `-hostname <hostname>`     |
+| `TSIDP_PORT=<port>`                      | `-port <port>`             |
+| `TSIDP_LOCAL_PORT=<port>`                | `-local-port <port>`       |
+| `TSIDP_PORT=<port>`                      | `-port <port>`             |
+| `TSIDP_LOCAL_PORT=<local-port>`          | `-local-port <local-port>` |
+| `TSIDP_USE_FUNNEL=1`                     | `-funnel`                  |
+| `TSIDP_ENABLE_STS=1`                     | `-enable-sts`              |
+| `TSIDP_LOG=<level>`                      | `-log <level>`             |
+| `TSIDP_DEBUG_TSNET=1`                    | `-debug-tsnet`             |
+| `TSIDP_DEBUG_ALL_REQUESTS=1`             | `-debug-all-requests`      |
+
+## Application Configuration Guides (WIP)
 
 tsidp can be used as IdP server for any application that supports custom OIDC providers.
 
@@ -125,42 +185,6 @@ tsidp supports all of the endpoints required & suggested by the [MCP Authorizati
 
 - [MCP Client / Server](./examples/mcp-server/README.md)
 - [MCP Client / Gateway Server](./examples/mcp-gateway/README.md)
-
-## tsidp Configuration Options
-
-The `tsidp` server is configured by several command-line flags:
-
-- `-verbose`: Enable verbose logging
-- `-port`: Port to listen on (default: 443)
-- `-local-port`: Allow requests from localhost
-- `-use-local-tailscaled`: Use local tailscaled instead of tsnet
-- `-funnel`: Use Tailscale Funnel to make tsidp available on the public internet so it works with SaaS products
-- `-hostname`: tsnet hostname
-- `-dir`: tsnet state directory
-- `-enable-sts`: Enable OAuth token exchange using RFC 8693
-- `-enable-debug`: Enable debug printing of requests to the server
-
-### Environment Variables
-
-These are needed while tsidp is in development (< v1.0.0):
-
-- `TAILSCALE_USE_WIP_CODE`: Enable work-in-progress code (default: "1", required)
-- `TS_AUTHKEY`: Your Tailscale authentication key (required)
-
-The docker container accepts environment variables that are mapped to the command-line flags:
-
-| Environment Variable            | CLI flag                   |
-| ------------------------------- | -------------------------- |
-| `TS_HOSTNAME=<hostname>`        | `-hostname <hostname>`     |
-| `TS_STATE_DIR=<directory>`      | `-dir <directory>`         |
-| `TSIDP_USE_FUNNEL=1`            | `-funnel`                  |
-| `TSIDP_PORT=<port>`             | `-port <port>`             |
-| `TSIDP_LOCAL_PORT=<local-port>` | `-local-port <local-port>` |
-| `TSIDP_ENABLE_STS=1`            | `-enable-sts`              |
-| `TSIDP_VERBOSE=1`               | `-verbose`                 |
-| `TSIDP_ENABLE_DEBUG=1`          | `-enable-debug`            |
-
-All environment variables are optional. When omitted the default value for the command-line flag will be used.
 
 ## Support
 

--- a/scripts/docker/run.sh
+++ b/scripts/docker/run.sh
@@ -27,16 +27,26 @@ if [ -n "$TSIDP_LOCAL_PORT" ]; then
     ARGS="$ARGS -local-port=$TSIDP_LOCAL_PORT"
 fi
 
-#
-# These flags will eventually be replaced
-# with more specific logging flags.
-#
-if [ -n "$TSIDP_VERBOSE" ]; then
-    ARGS="$ARGS -verbose"
+# logging control
+if [ -n "$TSIDP_LOG" ]; then
+    case "$TSIDP_LOG" in
+        debug|info|warn|error)
+            ARGS="$ARGS -log=$TSIDP_LOG"
+            ;;
+        *)
+            echo "Error: TSIDP_LOG_LEVEL must be one of: debug, info, warn, error"
+            echo "Current value: $TSIDP_LOG"
+            exit 1
+            ;;
+    esac
 fi
 
-if [ -n "$TSIDP_ENABLE_DEBUG" ]; then
-    ARGS="$ARGS -enable-debug"
+if [ -n "$TSIDP_DEBUG_ALL_REQUESTS" ]; then
+    ARGS="$ARGS -debug-all-requests"
+fi
+
+if [ -n "$TSIDP_DEBUG_TSNET" ]; then
+    ARGS="$ARGS -debug-tsnet"
 fi
 
 # Execute tsidp-server with the built arguments

--- a/server/appcap.go
+++ b/server/appcap.go
@@ -5,7 +5,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/netip"
 
@@ -91,13 +90,13 @@ func (s *IDPServer) addGrantAccessContext(handler http.HandlerFunc) http.Handler
 
 		who, err = s.lc.WhoIs(r.Context(), remoteAddr)
 		if err != nil {
-			http.Error(w, fmt.Sprintf("Error getting WhoIs: %v", err), http.StatusInternalServerError)
+			writeHTTPError(w, r, http.StatusInternalServerError, ecServerError, "Error getting WhoIs", err)
 			return
 		}
 
 		rules, err := tailcfg.UnmarshalCapJSON[capRule](who.CapMap, "tailscale.com/cap/tsidp")
 		if err != nil {
-			http.Error(w, fmt.Sprintf("failed unmarshaling app cap rule %s", err.Error()), http.StatusInternalServerError)
+			writeHTTPError(w, r, http.StatusInternalServerError, ecServerError, "failed unmarshaling app cap rule", err)
 			return
 		}
 		accessRules.rules = rules

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -378,6 +378,7 @@ func TestServeDynamicClientRegistration(t *testing.T) {
 			}
 
 			req := httptest.NewRequest(tt.method, "/register", body)
+			req.Header.Add("Accept", "application/json")
 			if tt.isFunnel {
 				req.Header.Set("Tailscale-Funnel-Request", "true")
 			}

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -249,7 +249,7 @@ func TestServeDynamicClientRegistration(t *testing.T) {
 			method:       "POST",
 			body:         `{"redirect_uris": ["https://example.com/callback"]}`,
 			isFunnel:     true,
-			expectStatus: http.StatusForbidden,
+			expectStatus: http.StatusUnauthorized,
 			checkResponse: func(t *testing.T, body []byte) {
 				var errResp map[string]interface{}
 				if err := json.Unmarshal(body, &errResp); err != nil {

--- a/server/extraclaims.go
+++ b/server/extraclaims.go
@@ -5,7 +5,7 @@ package server
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 )
 
 // withExtraClaims merges flattened extra claims from a list of capRule into the provided map[string]any,
@@ -27,7 +27,7 @@ func withExtraClaims(claimMap map[string]any, rules []capRule) (map[string]any, 
 	extra := flattenExtraClaims(rules)
 	for k, v := range extra {
 		if _, isProtected := protected[k]; isProtected {
-			log.Printf("Skip overwriting of existing claim %q", k)
+			slog.Info("Skip overwriting of existing claim", slog.String("claim", k))
 			return nil, fmt.Errorf("extra claim %q overwriting existing claim", k)
 		}
 

--- a/server/oauth-metadata.go
+++ b/server/oauth-metadata.go
@@ -96,10 +96,6 @@ func (s *IDPServer) serveOpenIDConfig(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}
-	if r.URL.Path != "/.well-known/openid-configuration" {
-		writeHTTPError(w, r, http.StatusNotFound, ecNotFound, "not found", nil)
-		return
-	}
 
 	w.Header().Set("Content-Type", "application/json")
 	je := json.NewEncoder(w)
@@ -149,10 +145,6 @@ func (s *IDPServer) serveOAuthMetadata(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}
-	if r.URL.Path != "/.well-known/oauth-authorization-server" {
-		writeHTTPError(w, r, http.StatusNotFound, ecNotFound, "not found", nil)
-		return
-	}
 
 	w.Header().Set("Content-Type", "application/json")
 	je := json.NewEncoder(w)
@@ -192,11 +184,6 @@ func (s *IDPServer) serveOAuthMetadata(w http.ResponseWriter, r *http.Request) {
 // serveJWKS serves the JSON Web Key Set endpoint
 // Migrated from legacy/tsidp.go:1723-1750
 func (s *IDPServer) serveJWKS(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Path != "/.well-known/jwks.json" {
-		writeHTTPError(w, r, http.StatusNotFound, ecNotFound, "endpoint not found", nil)
-		return
-	}
-
 	h := w.Header()
 	h.Set("Access-Control-Allow-Origin", "*")
 	h.Set("Access-Control-Allow-Method", "GET, OPTIONS")

--- a/server/oauth-metadata.go
+++ b/server/oauth-metadata.go
@@ -97,7 +97,7 @@ func (s *IDPServer) serveOpenIDConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if r.URL.Path != "/.well-known/openid-configuration" {
-		http.Error(w, "tsidp: not found", http.StatusNotFound)
+		writeHTTPError(w, r, http.StatusNotFound, ecNotFound, "not found", nil)
 		return
 	}
 
@@ -132,7 +132,7 @@ func (s *IDPServer) serveOpenIDConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := je.Encode(metadata); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeHTTPError(w, r, http.StatusInternalServerError, ecServerError, "failed to encode metadata", err)
 	}
 }
 
@@ -150,7 +150,7 @@ func (s *IDPServer) serveOAuthMetadata(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if r.URL.Path != "/.well-known/oauth-authorization-server" {
-		http.Error(w, "tsidp: not found", http.StatusNotFound)
+		writeHTTPError(w, r, http.StatusNotFound, ecNotFound, "not found", nil)
 		return
 	}
 
@@ -185,7 +185,7 @@ func (s *IDPServer) serveOAuthMetadata(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := je.Encode(metadata); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeHTTPError(w, r, http.StatusInternalServerError, ecServerError, "failed to encode metadata", err)
 	}
 }
 
@@ -193,7 +193,7 @@ func (s *IDPServer) serveOAuthMetadata(w http.ResponseWriter, r *http.Request) {
 // Migrated from legacy/tsidp.go:1723-1750
 func (s *IDPServer) serveJWKS(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path != "/.well-known/jwks.json" {
-		writeJSONError(w, http.StatusNotFound, "not_found", "endpoint not found")
+		writeHTTPError(w, r, http.StatusNotFound, ecNotFound, "endpoint not found", nil)
 		return
 	}
 
@@ -211,7 +211,7 @@ func (s *IDPServer) serveJWKS(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	sk, err := s.oidcPrivateKey()
 	if err != nil {
-		writeJSONError(w, http.StatusInternalServerError, "server_error", "internal server error")
+		writeHTTPError(w, r, http.StatusInternalServerError, ecServerError, "internal server error", err)
 		return
 	}
 	// TODO(maisem): maybe only marshal this once and reuse?
@@ -228,7 +228,7 @@ func (s *IDPServer) serveJWKS(w http.ResponseWriter, r *http.Request) {
 			},
 		},
 	}); err != nil {
-		writeJSONError(w, http.StatusInternalServerError, "server_error", "internal server error")
+		writeHTTPError(w, r, http.StatusInternalServerError, ecServerError, "internal server error", err)
 	}
 }
 
@@ -252,23 +252,4 @@ func isFunnelRequest(r *http.Request) bool {
 		return true
 	}
 	return false
-}
-
-// writeJSONError writes a JSON error response
-// Migrated from legacy/tsidp.go:1619-1626
-func writeJSONError(w http.ResponseWriter, statusCode int, errorCode, errorDescription string) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(statusCode)
-	json.NewEncoder(w).Encode(oauthErrorResponse{
-		Error:            errorCode,
-		ErrorDescription: errorDescription,
-	})
-}
-
-// oauthErrorResponse represents an OAuth 2.0 error response
-// Migrated from legacy/tsidp.go:1613-1617
-type oauthErrorResponse struct {
-	Error            string `json:"error"`
-	ErrorDescription string `json:"error_description,omitempty"`
-	ErrorURI         string `json:"error_uri,omitempty"`
 }

--- a/server/oauth-metadata_test.go
+++ b/server/oauth-metadata_test.go
@@ -87,7 +87,7 @@ func TestMetadataEndpoints(t *testing.T) {
 				"token_endpoint",
 				"jwks_uri",
 			}
-			
+
 			// OpenID specific endpoints
 			if strings.Contains(tt.endpoint, "openid") {
 				expectedEndpoints = append(expectedEndpoints, "userinfo_endpoint")
@@ -250,19 +250,19 @@ func TestPKCEMetadata(t *testing.T) {
 // TestMetadataSTSSupport tests that STS token exchange grant is properly advertised when enabled
 func TestMetadataSTSSupport(t *testing.T) {
 	tests := []struct {
-		name              string
-		enableSTS         bool
-		expectSTSGrant    bool
+		name           string
+		enableSTS      bool
+		expectSTSGrant bool
 	}{
 		{
-			name:              "STS disabled",
-			enableSTS:         false,
-			expectSTSGrant:    false,
+			name:           "STS disabled",
+			enableSTS:      false,
+			expectSTSGrant: false,
 		},
 		{
-			name:              "STS enabled",
-			enableSTS:         true,
-			expectSTSGrant:    true,
+			name:           "STS enabled",
+			enableSTS:      true,
+			expectSTSGrant: true,
 		},
 	}
 
@@ -373,21 +373,5 @@ func TestJWKSEndpoint(t *testing.T) {
 		if use, ok := key["use"].(string); !ok || use != "sig" {
 			t.Error("expected use to be sig")
 		}
-	}
-}
-
-// TestJWKSEndpointInvalidPath tests that JWKS endpoint returns 404 for invalid paths
-func TestJWKSEndpointInvalidPath(t *testing.T) {
-	s := &IDPServer{
-		serverURL: "https://idp.test.ts.net",
-	}
-
-	req := httptest.NewRequest("GET", "/invalid/path", nil)
-	rr := httptest.NewRecorder()
-
-	s.serveJWKS(rr, req)
-
-	if rr.Code != http.StatusNotFound {
-		t.Errorf("expected status 404, got %d", rr.Code)
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -489,17 +489,15 @@ func writeHTTPError(
 
 	acceptHeader := r.Header.Get("Accept")
 	switch {
-	case strings.Contains(acceptHeader, "text/html"):
-		fallthrough
-	case strings.Contains(acceptHeader, "text/plain"):
-		w.Header().Set("Content-Type", "text/plain; charset=UTF-8")
-		fmt.Fprintf(w, "Error %d: %s - %s", statusCode, errorCode, errorDescription)
-	default:
+	case strings.Contains(acceptHeader, "application/json"):
 		w.Header().Set("Content-Type", "application/json;charset=UTF-8")
 		json.NewEncoder(w).Encode(httpErrorResponse{
 			Error:            errorCode,
 			ErrorDescription: errorDescription,
 		})
+	default:
+		w.Header().Set("Content-Type", "text/plain; charset=UTF-8")
+		fmt.Fprintf(w, "Error %d: %s - %s", statusCode, errorCode, errorDescription)
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -453,7 +453,7 @@ func ServeOnLocalTailscaled(ctx context.Context, lc *local.Client, st *ipnstate.
 //   - r: *http.Request to inspect Accept header and method/path for logging
 //   - statusCode: HTTP status code (e.g., 400, 401, 403, 500)
 //   - errorCode: Unique error code, use constants: ecAccessDenied, ecInvalidRequest, etc.
-//   - errorDescription: Human-readable error description
+//   - errorDescription: Human-readable error description sent in the response body
 //   - err: Optional underlying error for additional logging context
 func writeHTTPError(
 	w http.ResponseWriter,

--- a/server/server.go
+++ b/server/server.go
@@ -466,8 +466,8 @@ func writeHTTPError(
 		slog.Int("status", statusCode),
 		slog.String("method", r.Method),
 		slog.String("path", r.URL.Path),
-		slog.String("error", errorCode),
-		slog.String("description", errorDescription),
+		slog.String("code", errorCode),
+		slog.String("desc", errorDescription),
 	}
 
 	if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -14,7 +14,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net"
 	"net/http"
 	"os"
@@ -139,14 +139,23 @@ type ActorClaim struct {
 	Actor    *ActorClaim `json:"act,omitempty"` // Nested for delegation chains
 }
 
-// FunnelClient represents an OAuth client accessing the IDP via Funnel
-
 // signingKey represents a JWT signing key
 // Migrated from legacy/tsidp.go:2336-2339
 type signingKey struct {
 	Kid uint64          `json:"kid"`
 	Key *rsa.PrivateKey `json:"-"`
 }
+
+// for use with writeHTTPError() errorCode parameter
+const (
+	ecAccessDenied     = "access_denied"
+	ecInvalidRequest   = "invalid_request"
+	ecInvalidClient    = "invalid_client"
+	ecInvalidGrant     = "invalid_grant"
+	ecServerError      = "server_error"
+	ecNotFound         = "not_found"
+	ecUnsupportedGrant = "unsupported_grant_type"
+)
 
 // New creates a new IDPServer instance
 func New(lc *local.Client, stateDir string, funnel, localTSMode, enableSTS bool) *IDPServer {
@@ -284,7 +293,7 @@ func (s *IDPServer) oidcPrivateKey() (*signingKey, error) {
 			if err := json.Unmarshal(b, &sk); err == nil {
 				return &sk, nil
 			} else {
-				log.Printf("Error unmarshaling key: %v", err)
+				slog.Error("Error unmarshaling oidc key", slog.Any("error", err))
 			}
 		}
 		id, k := mustGenRSAKey(2048)
@@ -292,10 +301,12 @@ func (s *IDPServer) oidcPrivateKey() (*signingKey, error) {
 		sk.Kid = id
 		b, err = json.Marshal(&sk)
 		if err != nil {
-			log.Fatalf("Error marshaling key: %v", err)
+			slog.Error("Error marshaling key", slog.Any("error", err))
+			os.Exit(1)
 		}
 		if err := os.WriteFile(keyPath, b, 0600); err != nil {
-			log.Fatalf("Error writing key: %v", err)
+			slog.Error("Error writing oid key", slog.Any("error", err))
+			os.Exit(1)
 		}
 		return &sk, nil
 	})
@@ -432,4 +443,67 @@ func ServeOnLocalTailscaled(ctx context.Context, lc *local.Client, st *ipnstate.
 	}
 
 	return func() { watcher.Close() }, watcherChan, nil
+}
+
+// writeHTTPError writes an appropriate HTTP error response based on the request's Accept header.
+// It logs the error with appropriate severity level and sends either JSON or plain text response.
+//
+// Parameters:
+//   - w: http.ResponseWriter to write the response
+//   - r: *http.Request to inspect Accept header and method/path for logging
+//   - statusCode: HTTP status code (e.g., 400, 401, 403, 500)
+//   - errorCode: Unique error code, use constants: ecAccessDenied, ecInvalidRequest, etc.
+//   - errorDescription: Human-readable error description
+//   - err: Optional underlying error for additional logging context
+func writeHTTPError(
+	w http.ResponseWriter,
+	r *http.Request,
+	statusCode int,
+	errorCode, errorDescription string,
+	err error,
+) {
+	args := []any{
+		slog.Int("status", statusCode),
+		slog.String("method", r.Method),
+		slog.String("path", r.URL.Path),
+		slog.String("error", errorCode),
+		slog.String("description", errorDescription),
+	}
+
+	if err != nil {
+		args = append(args, slog.String("error", err.Error()))
+	}
+
+	switch statusCode {
+	case http.StatusForbidden, http.StatusUnauthorized:
+		slog.Warn("HTTP error", args...)
+	case http.StatusInternalServerError:
+		slog.Error("HTTP error", args...)
+	default:
+		slog.Debug("HTTP error", args...)
+	}
+
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
+	w.WriteHeader(statusCode)
+
+	acceptHeader := r.Header.Get("Accept")
+	switch {
+	case strings.Contains(acceptHeader, "text/html"):
+		fallthrough
+	case strings.Contains(acceptHeader, "text/plain"):
+		w.Header().Set("Content-Type", "text/plain; charset=UTF-8")
+		fmt.Fprintf(w, "Error %d: %s - %s", statusCode, errorCode, errorDescription)
+	default:
+		w.Header().Set("Content-Type", "application/json;charset=UTF-8")
+		json.NewEncoder(w).Encode(httpErrorResponse{
+			Error:            errorCode,
+			ErrorDescription: errorDescription,
+		})
+	}
+}
+
+type httpErrorResponse struct {
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description,omitempty"`
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -110,7 +110,7 @@ func TestSetFunnelClients(t *testing.T) {
 	}
 }
 
-// TestCleanupExpiredTokens tests token cleanup  
+// TestCleanupExpiredTokens tests token cleanup
 // Enhanced migration combining legacy/tsidp_test.go:833-867 and legacy/tsidp_test.go:2310-2331
 // Tests cleanup of authorization codes, access tokens, and refresh tokens
 func TestCleanupExpiredTokens(t *testing.T) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -4,9 +4,15 @@
 package server
 
 import (
+	"log/slog"
 	"testing"
 	"time"
 )
+
+func init() {
+	// change from default INFO level to reduce noise in tests
+	slog.SetLogLoggerLevel(slog.LevelError)
+}
 
 // TestNew tests creation of a new IDPServer
 func TestNew(t *testing.T) {

--- a/server/token.go
+++ b/server/token.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/netip"
 	"strings"
@@ -160,7 +161,8 @@ func (s *IDPServer) serveToken(w http.ResponseWriter, r *http.Request) {
 		}
 		s.serveTokenExchange(w, r)
 	default:
-		writeHTTPError(w, r, http.StatusBadRequest, ecUnsupportedGrant, "grant type sent: "+grantType, nil)
+		writeHTTPError(w, r, http.StatusBadRequest, ecUnsupportedGrant, "unsupported grant type",
+			fmt.Errorf("unsupported grant type %q", grantType))
 	}
 }
 
@@ -187,7 +189,8 @@ func (s *IDPServer) handleAuthorizationCodeGrant(w http.ResponseWriter, r *http.
 		return
 	}
 	if ar.RedirectURI != r.FormValue("redirect_uri") {
-		writeHTTPError(w, r, http.StatusBadRequest, ecInvalidGrant, "redirect_uri mismatch", nil)
+		writeHTTPError(w, r, http.StatusBadRequest, ecInvalidGrant, "redirect_uri mismatch",
+			fmt.Errorf("got redirect_uri %q, want %q", r.FormValue("redirect_uri"), ar.RedirectURI))
 		return
 	}
 
@@ -610,6 +613,13 @@ func (s *IDPServer) issueTokens(w http.ResponseWriter, r *http.Request, ar *Auth
 	rtAuth.ValidTill = now.Add(30 * 24 * time.Hour) // 30 days
 	mak.Set(&s.refreshToken, rt, &rtAuth)
 	s.mu.Unlock()
+
+	slog.Info("token issued",
+		slog.String("for", who.UserProfile.LoginName),
+		slog.String("uid", n.User().String()),
+		slog.String("client_id", ar.ClientID),
+		slog.String("redirect_uri", ar.RedirectURI),
+	)
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(oidcTokenResponse{

--- a/server/token.go
+++ b/server/token.go
@@ -189,7 +189,7 @@ func (s *IDPServer) handleAuthorizationCodeGrant(w http.ResponseWriter, r *http.
 		return
 	}
 	if ar.RedirectURI != r.FormValue("redirect_uri") {
-		writeHTTPError(w, r, http.StatusBadRequest, ecInvalidGrant, "redirect_uri mismatch",
+		writeHTTPError(w, r, http.StatusBadRequest, ecInvalidRequest, "redirect_uri mismatch",
 			fmt.Errorf("got redirect_uri %q, want %q", r.FormValue("redirect_uri"), ar.RedirectURI))
 		return
 	}

--- a/server/token.go
+++ b/server/token.go
@@ -143,7 +143,7 @@ func (s *IDPServer) serveToken(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if r.Method != "POST" {
-		http.Error(w, "tsidp: method not allowed", http.StatusMethodNotAllowed)
+		writeHTTPError(w, r, http.StatusMethodNotAllowed, ecInvalidRequest, "method not allowed", nil)
 		return
 	}
 
@@ -155,12 +155,12 @@ func (s *IDPServer) serveToken(w http.ResponseWriter, r *http.Request) {
 		s.handleRefreshTokenGrant(w, r)
 	case "urn:ietf:params:oauth:grant-type:token-exchange":
 		if !s.enableSTS {
-			writeTokenEndpointError(w, http.StatusBadRequest, "unsupported_grant_type", "token exchange not enabled")
+			writeHTTPError(w, r, http.StatusBadRequest, ecUnsupportedGrant, "token exchange not enabled", nil)
 			return
 		}
 		s.serveTokenExchange(w, r)
 	default:
-		writeTokenEndpointError(w, http.StatusBadRequest, "unsupported_grant_type", "")
+		writeHTTPError(w, r, http.StatusBadRequest, ecUnsupportedGrant, "grant type sent: "+grantType, nil)
 	}
 }
 
@@ -169,7 +169,7 @@ func (s *IDPServer) serveToken(w http.ResponseWriter, r *http.Request) {
 func (s *IDPServer) handleAuthorizationCodeGrant(w http.ResponseWriter, r *http.Request) {
 	code := r.FormValue("code")
 	if code == "" {
-		writeTokenEndpointError(w, http.StatusBadRequest, "invalid_request", "code is required")
+		writeHTTPError(w, r, http.StatusBadRequest, ecInvalidRequest, "code is required", nil)
 		return
 	}
 	s.mu.Lock()
@@ -179,16 +179,15 @@ func (s *IDPServer) handleAuthorizationCodeGrant(w http.ResponseWriter, r *http.
 	}
 	s.mu.Unlock()
 	if !ok {
-		writeTokenEndpointError(w, http.StatusBadRequest, "invalid_grant", "code not found")
+		writeHTTPError(w, r, http.StatusBadRequest, ecInvalidGrant, "code not found", nil)
 		return
 	}
 	if httpStatusCode, err := ar.allowRelyingParty(r); err != nil {
-		//log.Printf("XXX Error allowing relying party: %v", err)
-		writeTokenEndpointError(w, httpStatusCode, "invalid_client", err.Error())
+		writeHTTPError(w, r, httpStatusCode, ecInvalidClient, "client authentication failed", err)
 		return
 	}
 	if ar.RedirectURI != r.FormValue("redirect_uri") {
-		writeTokenEndpointError(w, http.StatusBadRequest, "invalid_grant", "redirect_uri mismatch")
+		writeHTTPError(w, r, http.StatusBadRequest, ecInvalidGrant, "redirect_uri mismatch", nil)
 		return
 	}
 
@@ -196,12 +195,12 @@ func (s *IDPServer) handleAuthorizationCodeGrant(w http.ResponseWriter, r *http.
 	if ar.CodeChallenge != "" {
 		codeVerifier := r.FormValue("code_verifier")
 		if codeVerifier == "" {
-			writeTokenEndpointError(w, http.StatusBadRequest, "invalid_request", "code_verifier is required")
+			writeHTTPError(w, r, http.StatusBadRequest, ecInvalidRequest, "code_verifier is required", nil)
 			return
 		}
 
 		if err := validateCodeVerifier(codeVerifier, ar.CodeChallenge, ar.CodeChallengeMethod); err != nil {
-			writeTokenEndpointError(w, http.StatusBadRequest, "invalid_grant", err.Error())
+			writeHTTPError(w, r, http.StatusBadRequest, ecInvalidGrant, "code verification failed", err)
 			return
 		}
 	}
@@ -212,15 +211,14 @@ func (s *IDPServer) handleAuthorizationCodeGrant(w http.ResponseWriter, r *http.
 		// Validate requested resources using the same capability would be used for STS
 		validatedResources, err := s.validateResourcesForUser(ar.RemoteUser, resources)
 		if err != nil {
-			//log.Printf("Error validating resources: %v", err)
-			writeTokenEndpointError(w, http.StatusBadRequest, "invalid_request", "invalid resource")
+			writeHTTPError(w, r, http.StatusBadRequest, ecInvalidRequest, "invalid resource", err)
 			return
 		}
 		ar.Resources = validatedResources
 	}
 	// If no resources in token request, use the ones from authorization
 
-	s.issueTokens(w, ar)
+	s.issueTokens(w, r, ar)
 }
 
 // handleRefreshTokenGrant handles the refresh token grant type
@@ -228,7 +226,7 @@ func (s *IDPServer) handleAuthorizationCodeGrant(w http.ResponseWriter, r *http.
 func (s *IDPServer) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Request) {
 	rt := r.FormValue("refresh_token")
 	if rt == "" {
-		writeTokenEndpointError(w, http.StatusBadRequest, "invalid_request", "refresh_token is required")
+		writeHTTPError(w, r, http.StatusBadRequest, ecInvalidRequest, "refresh_token is required", nil)
 		return
 	}
 
@@ -242,14 +240,13 @@ func (s *IDPServer) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Reque
 	s.mu.Unlock()
 
 	if !ok {
-		writeTokenEndpointError(w, http.StatusBadRequest, "invalid_grant", "invalid refresh token")
+		writeHTTPError(w, r, http.StatusBadRequest, ecInvalidGrant, "invalid refresh token", nil)
 		return
 	}
 
 	// Validate client authentication
 	if httpStatusCode, err := ar.allowRelyingParty(r); err != nil {
-		//log.Printf("Error allowing relying party: %v", err)
-		writeTokenEndpointError(w, httpStatusCode, "invalid_client", err.Error())
+		writeHTTPError(w, r, httpStatusCode, ecInvalidClient, "client authentication failed", err)
 		return
 	}
 
@@ -259,8 +256,7 @@ func (s *IDPServer) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Reque
 		// Validate requested resources are a subset of original grant
 		validatedResources, err := s.validateResourcesForUser(ar.RemoteUser, resources)
 		if err != nil {
-			//log.Printf("Error validating resources: %v", err)
-			writeTokenEndpointError(w, http.StatusBadRequest, "invalid_request", err.Error())
+			writeHTTPError(w, r, http.StatusBadRequest, ecInvalidRequest, "resource validation failed", err)
 			return
 		}
 
@@ -275,7 +271,7 @@ func (s *IDPServer) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Reque
 					}
 				}
 				if !found {
-					writeTokenEndpointError(w, http.StatusBadRequest, "invalid_request", "requested resource not in original grant")
+					writeHTTPError(w, r, http.StatusBadRequest, ecInvalidRequest, "requested resource not in original grant", nil)
 					return
 				}
 			}
@@ -292,53 +288,53 @@ func (s *IDPServer) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Reque
 	delete(s.refreshToken, rt)
 	s.mu.Unlock()
 
-	s.issueTokens(w, ar)
+	s.issueTokens(w, r, ar)
 }
 
 // serveTokenExchange implements the OIDC STS token exchange flow per RFC 8693
 // Migrated from legacy/tsidp.go:1012-1210
 func (s *IDPServer) serveTokenExchange(w http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
-		http.Error(w, "tsidp: method not allowed", http.StatusMethodNotAllowed)
+		writeHTTPError(w, r, http.StatusMethodNotAllowed, ecInvalidRequest, "method not allowed", nil)
 		return
 	}
 
 	// Parse form data
 	if err := r.ParseForm(); err != nil {
-		writeTokenEndpointError(w, http.StatusBadRequest, "invalid_request", "failed to parse form")
+		writeHTTPError(w, r, http.StatusBadRequest, ecInvalidRequest, "failed to parse form", err)
 		return
 	}
 
 	// Validate required parameters
 	subjectToken := r.FormValue("subject_token")
 	if subjectToken == "" {
-		writeTokenEndpointError(w, http.StatusBadRequest, "invalid_request", "subject_token is required")
+		writeHTTPError(w, r, http.StatusBadRequest, ecInvalidRequest, "subject_token is required", nil)
 		return
 	}
 
 	subjectTokenType := r.FormValue("subject_token_type")
 	if subjectTokenType != "urn:ietf:params:oauth:token-type:access_token" {
-		writeTokenEndpointError(w, http.StatusBadRequest, "invalid_request", "unsupported subject_token_type")
+		writeHTTPError(w, r, http.StatusBadRequest, ecInvalidRequest, "unsupported subject_token_type", nil)
 		return
 	}
 
 	requestedTokenType := r.FormValue("requested_token_type")
 	if requestedTokenType != "" && requestedTokenType != "urn:ietf:params:oauth:token-type:access_token" {
-		writeTokenEndpointError(w, http.StatusBadRequest, "invalid_request", "unsupported requested_token_type")
+		writeHTTPError(w, r, http.StatusBadRequest, ecInvalidRequest, "unsupported requested_token_type", nil)
 		return
 	}
 
 	// Parse multiple audience parameters (RFC 8693 allows multiple)
 	audiences := r.Form["audience"]
 	if len(audiences) == 0 {
-		writeTokenEndpointError(w, http.StatusBadRequest, "invalid_request", "audience is required")
+		writeHTTPError(w, r, http.StatusBadRequest, ecInvalidRequest, "audience is required", nil)
 		return
 	}
 
 	// Identify the client performing the exchange
 	exchangingClientID := s.identifyClient(r)
 	if exchangingClientID == "" {
-		writeTokenEndpointError(w, http.StatusUnauthorized, "invalid_client", "invalid client credentials")
+		writeHTTPError(w, r, http.StatusUnauthorized, ecInvalidClient, "invalid client credentials", nil)
 		return
 	}
 
@@ -355,12 +351,12 @@ func (s *IDPServer) serveTokenExchange(w http.ResponseWriter, r *http.Request) {
 	ar, ok := s.accessToken[subjectToken]
 	s.mu.Unlock()
 	if !ok {
-		writeTokenEndpointError(w, http.StatusUnauthorized, "invalid_grant", "invalid subject token")
+		writeHTTPError(w, r, http.StatusUnauthorized, ecInvalidGrant, "invalid subject token", nil)
 		return
 	}
 
 	if ar.ValidTill.Before(time.Now()) {
-		writeTokenEndpointError(w, http.StatusUnauthorized, "invalid_grant", "subject token expired")
+		writeHTTPError(w, r, http.StatusUnauthorized, ecInvalidGrant, "subject token expired", nil)
 		return
 	}
 
@@ -368,8 +364,7 @@ func (s *IDPServer) serveTokenExchange(w http.ResponseWriter, r *http.Request) {
 	who := ar.RemoteUser
 	rules, err := tailcfg.UnmarshalCapJSON[capRule](who.CapMap, "tailscale.com/cap/tsidp")
 	if err != nil {
-		//log.Printf("tsidp: failed to unmarshal STS capability: %v", err)
-		writeTokenEndpointError(w, http.StatusForbidden, "access_denied", fmt.Sprintf("failed to unmarshal STS capability: %s", err.Error()))
+		writeHTTPError(w, r, http.StatusForbidden, ecAccessDenied, "failed to unmarshal STS capability", err)
 		return
 	}
 
@@ -407,7 +402,7 @@ func (s *IDPServer) serveTokenExchange(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(allowedAudiences) == 0 {
-		writeTokenEndpointError(w, http.StatusForbidden, "access_denied", "access denied for requested audience")
+		writeHTTPError(w, r, http.StatusForbidden, ecAccessDenied, "access denied for requested audience", nil)
 		return
 	}
 
@@ -416,7 +411,7 @@ func (s *IDPServer) serveTokenExchange(w http.ResponseWriter, r *http.Request) {
 	if actorTokenParam := r.FormValue("actor_token"); actorTokenParam != "" {
 		actorTokenType := r.FormValue("actor_token_type")
 		if actorTokenType != "" && actorTokenType != "urn:ietf:params:oauth:token-type:access_token" {
-			writeTokenEndpointError(w, http.StatusBadRequest, "invalid_request", "unsupported actor_token_type")
+			writeHTTPError(w, r, http.StatusBadRequest, ecInvalidRequest, "unsupported actor_token_type", nil)
 			return
 		}
 
@@ -425,7 +420,7 @@ func (s *IDPServer) serveTokenExchange(w http.ResponseWriter, r *http.Request) {
 		actorAR, ok := s.accessToken[actorTokenParam]
 		s.mu.Unlock()
 		if !ok || actorAR.ValidTill.Before(time.Now()) {
-			writeTokenEndpointError(w, http.StatusBadRequest, "invalid_request", "invalid or expired actor_token")
+			writeHTTPError(w, r, http.StatusBadRequest, ecInvalidRequest, "invalid or expired actor_token", nil)
 			return
 		}
 
@@ -493,17 +488,16 @@ func (s *IDPServer) serveTokenExchange(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := json.NewEncoder(w).Encode(response); err != nil {
-		writeTokenEndpointError(w, http.StatusInternalServerError, "server_error", "internal server error")
+		writeHTTPError(w, r, http.StatusInternalServerError, ecServerError, "internal server error", err)
 	}
 }
 
 // issueTokens issues access and refresh tokens
 // Migrated from legacy/tsidp.go:1339-1473
-func (s *IDPServer) issueTokens(w http.ResponseWriter, ar *AuthRequest) {
+func (s *IDPServer) issueTokens(w http.ResponseWriter, r *http.Request, ar *AuthRequest) {
 	signer, err := s.oidcSigner()
 	if err != nil {
-		//log.Printf("Error getting signer: %v", err)
-		writeTokenEndpointError(w, http.StatusInternalServerError, "server_error", "internal server error - could not get signer")
+		writeHTTPError(w, r, http.StatusInternalServerError, ecServerError, "internal server error - could not get signer", err)
 		return
 	}
 	jti := rands.HexString(32)
@@ -511,7 +505,7 @@ func (s *IDPServer) issueTokens(w http.ResponseWriter, ar *AuthRequest) {
 
 	n := who.Node.View()
 	if n.IsTagged() {
-		writeTokenEndpointError(w, http.StatusBadRequest, "invalid_request", "tagged nodes not supported")
+		writeHTTPError(w, r, http.StatusBadRequest, ecInvalidRequest, "tagged nodes not supported", nil)
 		return
 	}
 
@@ -583,15 +577,13 @@ func (s *IDPServer) issueTokens(w http.ResponseWriter, ar *AuthRequest) {
 
 	rules, err := tailcfg.UnmarshalCapJSON[capRule](who.CapMap, tailcfg.PeerCapabilityTsIDP)
 	if err != nil {
-		//log.Printf("tsidp: failed to unmarshal capability: %v", err)
-		writeTokenEndpointError(w, http.StatusBadRequest, "invalid_request", "failed to unmarshal capability")
+		writeHTTPError(w, r, http.StatusBadRequest, ecInvalidRequest, "failed to unmarshal capability", err)
 		return
 	}
 
 	tsClaimsWithExtra, err := withExtraClaims(tsClaims.toMap(), rules)
 	if err != nil {
-		//log.Printf("tsidp: failed to merge extra claims: %v", err)
-		writeTokenEndpointError(w, http.StatusBadRequest, "invalid_request", "failed to merge extra claims")
+		writeHTTPError(w, r, http.StatusBadRequest, ecInvalidRequest, "failed to merge extra claims", err)
 		return
 	}
 
@@ -603,8 +595,7 @@ func (s *IDPServer) issueTokens(w http.ResponseWriter, ar *AuthRequest) {
 	// Create an OIDC token using this issuer's signer.
 	token, err := jwt.Signed(signer).Claims(tsClaimsWithExtra).CompactSerialize()
 	if err != nil {
-		//log.Printf("Error getting token: %v", err)
-		writeTokenEndpointError(w, http.StatusInternalServerError, "server_error", "error creating token")
+		writeHTTPError(w, r, http.StatusInternalServerError, ecServerError, "error creating JWT token", err)
 		return
 	}
 
@@ -628,7 +619,7 @@ func (s *IDPServer) issueTokens(w http.ResponseWriter, ar *AuthRequest) {
 		IDToken:      token,
 		RefreshToken: rt,
 	}); err != nil {
-		writeTokenEndpointError(w, http.StatusInternalServerError, "server_error", "internal server error")
+		writeHTTPError(w, r, http.StatusInternalServerError, ecServerError, "internal server error", err)
 	}
 }
 
@@ -771,32 +762,18 @@ func generateCodeChallenge(verifier, method string) (string, error) {
 	}
 }
 
-// writeTokenEndpointError writes an RFC 6749 compliant token endpoint error response
-// Migrated from legacy/tsidp.go:1630-1639
-func writeTokenEndpointError(w http.ResponseWriter, statusCode int, errorCode, errorDescription string) {
-	w.Header().Set("Content-Type", "application/json;charset=UTF-8")
-	w.Header().Set("Cache-Control", "no-store")
-	w.Header().Set("Pragma", "no-cache")
-	w.WriteHeader(statusCode)
-	//log.Printf("XXX token endpoint error: %d > %s\n", statusCode, errorDescription)
-	json.NewEncoder(w).Encode(oauthErrorResponse{
-		Error:            errorCode,
-		ErrorDescription: errorDescription,
-	})
-}
-
 // serveIntrospect handles the /introspect endpoint for token introspection (RFC 7662)
 // Migrated from legacy/tsidp.go:1475-1602
 func (s *IDPServer) serveIntrospect(w http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
-		http.Error(w, "tsidp: method not allowed", http.StatusMethodNotAllowed)
+		writeHTTPError(w, r, http.StatusMethodNotAllowed, ecInvalidRequest, "method not allowed", nil)
 		return
 	}
 
 	// Parse the token parameter
 	token := r.FormValue("token")
 	if token == "" {
-		writeJSONError(w, http.StatusBadRequest, "invalid_request", "token is required")
+		writeHTTPError(w, r, http.StatusBadRequest, ecInvalidRequest, "token is required", nil)
 		return
 	}
 
@@ -906,7 +883,7 @@ func (s *IDPServer) serveIntrospect(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeHTTPError(w, r, http.StatusInternalServerError, ecServerError, "failed to encode response", err)
 	}
 }
 

--- a/server/token_test.go
+++ b/server/token_test.go
@@ -640,6 +640,7 @@ func TestRefreshTokenFlow(t *testing.T) {
 
 			req := httptest.NewRequest("POST", "/token", strings.NewReader(form.Encode()))
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			req.Header.Set("Accept", "application/json")
 
 			rr := httptest.NewRecorder()
 			s.serveToken(rr, req)
@@ -696,6 +697,7 @@ func TestTokenEndpointUnsupportedGrantType(t *testing.T) {
 			}
 
 			req := httptest.NewRequest("POST", "/token", strings.NewReader(form.Encode()))
+			req.Header.Set("Accept", "application/json")
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 			rr := httptest.NewRecorder()
@@ -769,6 +771,7 @@ func TestTokenExpiration(t *testing.T) {
 			}
 
 			req := httptest.NewRequest("GET", "/userinfo", nil)
+			req.Header.Set("Accept", "application/json")
 			req.Header.Set("Authorization", "Bearer "+testToken)
 
 			rr := httptest.NewRecorder()

--- a/server/token_test.go
+++ b/server/token_test.go
@@ -562,7 +562,7 @@ func TestRefreshTokenFlow(t *testing.T) {
 			clientSecret: "wrong-secret",
 			expectStatus: http.StatusBadRequest, // Both legacy and server should reject this
 			checkResponse: func(t *testing.T, body []byte) {
-				var resp oauthErrorResponse
+				var resp httpErrorResponse
 				if err := json.Unmarshal(body, &resp); err != nil {
 					t.Fatalf("failed to unmarshal response: %v", err)
 				}


### PR DESCRIPTION
This commit switches tsidp to slog and collapses HTTP error logging to a single function.

- use WARN/DEBUG level logging depending on http status code
- move tsnet.Server logging to new flag: -debug-tsnet
- move request/response logging to new flag: -debug-all-requests
- unify API error handling logic to writeHTTPError
    
Updates #25

Log output: 

```
2025/09/23 16:26:06 WARN HTTP error status=401 method=GET path=/ error=access_denied description="not available over funnel"
2025/09/23 16:26:35 WARN HTTP error status=401 method=GET path=/authorize error=access_denied description="not allowed over funnel"
2025/09/23 16:26:44 WARN HTTP error status=401 method=GET path=/authorize error=access_denied description="not allowed over funnel"
```

- 401, 403 are logged at a WARN level
- 500 logged at an ERR level
- all other HTTP errors logged at DEBUG level