### PR TITLE
server: add support for mobile URI schemes

### DIFF
--- a/server/ui.go
+++ b/server/ui.go
@@ -365,14 +365,15 @@ func (s *IDPServer) renderFormSuccess(w http.ResponseWriter, data clientDisplayD
 }
 
 // validateRedirectURI validates that a redirect URI is well-formed
-// Migrated from legacy/ui.go:358-367
 func validateRedirectURI(redirectURI string) string {
 	u, err := url.Parse(redirectURI)
-	if err != nil || u.Scheme == "" || u.Host == "" {
-		return "must be a valid HTTP or HTTPS URL"
+	if err != nil || u.Scheme == "" {
+		return "must be a valid URI with a scheme"
 	}
-	if u.Scheme != "http" && u.Scheme != "https" {
-		return "must use HTTP or HTTPS scheme"
+	if u.Scheme == "http" || u.Scheme == "https" {
+		if u.Host == "" {
+			return "HTTP and HTTPS URLs must have a host"
+		}
 	}
 	return ""
 }

--- a/server/ui_test.go
+++ b/server/ui_test.go
@@ -35,3 +35,76 @@ func TestUIDenyOnMissingApplicationGrant(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateRedirectURI(t *testing.T) {
+	tests := []struct {
+		name string
+		uri  string
+		want string
+	}{
+		{
+			name: "valid HTTPS URL",
+			uri:  "https://example.com/callback",
+			want: "",
+		},
+		{
+			name: "valid HTTP URL",
+			uri:  "http://localhost:3000/callback",
+			want: "",
+		},
+		{
+			name: "valid mobile app scheme",
+			uri:  "myapp://auth/callback",
+			want: "",
+		},
+		{
+			name: "valid custom scheme with subdomain",
+			uri:  "com.example.app://callback",
+			want: "",
+		},
+		{
+			name: "valid scheme with path and query",
+			uri:  "myapp://auth/callback?state=123",
+			want: "",
+		},
+		{
+			name: "missing scheme",
+			uri:  "example.com/callback",
+			want: "must be a valid URI with a scheme",
+		},
+		{
+			name: "empty URI",
+			uri:  "",
+			want: "must be a valid URI with a scheme",
+		},
+		{
+			name: "invalid URI",
+			uri:  "ht tp://invalid",
+			want: "must be a valid URI with a scheme",
+		},
+		{
+			name: "HTTP URL missing host",
+			uri:  "http:///callback",
+			want: "HTTP and HTTPS URLs must have a host",
+		},
+		{
+			name: "HTTPS URL missing host",
+			uri:  "https:///callback",
+			want: "HTTP and HTTPS URLs must have a host",
+		},
+		{
+			name: "custom scheme without host is valid",
+			uri:  "myapp:///callback",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := validateRedirectURI(tt.uri)
+			if got != tt.want {
+				t.Errorf("validateRedirectURI(%q) = %q, want %q", tt.uri, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Remove the constraint that redirect_uri must be only `http` or `https`. This will support flows in mobile application that use a `redirect_uri` like: `app.mymobile:///oauth-callback`

Fixes #60