### PR TITLE
feat: add ability to advertise tags when configuring tsidp

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ Once tsidp has started, visit `https://idp.yourtailnet.ts.net` in a browser to c
 > [!NOTE]
 > If you're running tsidp for the first time it may take a few minutes for the TLS certificate to generate. You may not be able to access the service until the certificate is ready.
 
+> [!NOTE] Using OAuth Client Secrets
+> As an alternative to traditional auth keys, you can use OAuth client secrets for authentication by passing them through `TS_AUTHKEY`.
+>
+> When using OAuth client secrets:
+> - Pass the OAuth client secret through `TS_AUTHKEY` (same as regular auth keys)
+> - Specify advertise tags using `TS_ADVERTISE_TAGS`
+> - The OAuth client secret must start with `tskey-client-`
+> - The tags must be properly configured in your Tailscale ACL policy
+
 ### Other Ways to Build and Run
 
 <details>
@@ -162,7 +171,11 @@ The `tsidp-server` binary is configured through the CLI flags above. However, th
 
 These environment variables are used when tsidp does not have any state information set in `-dir <path>`.
 
-- `TS_AUTHKEY=<key>`: Key for registering a tsidp as a new node on your tailnet. If omitted a link will be printed to manually register.
+> [!WARNING]
+> **Serverless/Stateless Deployment**: tsidp requires persistent state storage to function properly in production. Without a persistent `-dir`, the service will re-register with Tailscale on every restart, lose dynamic OIDC client registrations, and invalidate user sessions. Serverless environments without persistent storage are not recommended for production use.
+
+- `TS_AUTHKEY=<key>`: Key for registering a tsidp as a new node on your tailnet. Can be a traditional auth key or OAuth client secret (tskey-client-xxx). If omitted, a link will be printed to manually register.
+- `TS_ADVERTISE_TAGS=<tags>`: Comma-separated advertise tags (e.g., "tag:tsidp,tag:server"). Optional, but required when using OAuth client secrets.
 - `TSNET_FORCE_LOGIN=1`: Force re-login of the node. Useful during development.
 
 ### Docker Environment Variables
@@ -182,6 +195,8 @@ The Docker image exposes the CLI flags through environment variables. If omitted
 | `TSIDP_LOG=<level>`                      | `-log <level>`             |
 | `TSIDP_DEBUG_TSNET=1`                    | `-debug-tsnet`             |
 | `TSIDP_DEBUG_ALL_REQUESTS=1`             | `-debug-all-requests`      |
+| `TS_AUTHKEY=<key>`                       | _(env var only)_           |
+| `TS_ADVERTISE_TAGS=<tags>`               | _(env var only)_           |
 
 ## Application Configuration Guides (WIP)
 

--- a/tsidp-server.go
+++ b/tsidp-server.go
@@ -125,6 +125,16 @@ func main() {
 			Hostname: *flagHostname,
 			Dir:      *flagDir,
 		}
+
+		if advertiseTags := os.Getenv("TS_ADVERTISE_TAGS"); advertiseTags != "" {
+			tags := strings.Split(advertiseTags, ",")
+			for i, tag := range tags {
+				tags[i] = strings.TrimSpace(tag)
+			}
+			ts.AdvertiseTags = tags
+			slog.Info("Using advertise tags", slog.String("tags", strings.Join(tags, ",")))
+		}
+
 		if *flagDebugTSNet {
 			ts.Logf = func(format string, args ...any) {
 				cur := slog.SetLogLoggerLevel(slog.LevelDebug) // force debug if this option is on
@@ -132,16 +142,19 @@ func main() {
 				slog.SetLogLoggerLevel(cur)
 			}
 		}
+
 		st, err = ts.Up(ctx)
 		if err != nil {
 			slog.Error("failed to start tsnet server", slog.Any("error", err))
 			os.Exit(1)
 		}
+
 		lc, err = ts.LocalClient()
 		if err != nil {
 			slog.Error("failed to get local client", slog.Any("error", err))
 			os.Exit(1)
 		}
+
 		var ln net.Listener
 		if *flagFunnel {
 			if err := ipn.CheckFunnelAccess(uint16(*flagPort), st.Self); err != nil {


### PR DESCRIPTION
~- Add OAuth client secret authentication as alternative to traditional auth keys~
- Update documentation with OAuth configuration and minor cleanup
~- Upgrade to Golang 1.25.1 (required for upgraded tailscale dep for oauth support)~
- Add ability to advertise tags

note: many things are resolved (and now removed) from this PR as a result of https://github.com/tailscale/tsidp/pull/152 but we still need the ability to advertise tags to make this feature complete

Closes https://github.com/tailscale/tsidp/issues/49
Updates https://github.com/tailscale/tailscale/pull/17191