### PR TITLE
server/token.go: change emailish emails into realish looking ones

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -55,11 +55,11 @@ func TestNew(t *testing.T) {
 func TestSetServerURL(t *testing.T) {
 	srv := New(nil, "", false, false, false)
 
-	testURL := "https://test.example.com"
-	srv.SetServerURL(testURL)
+	hostname := "test.example.com"
+	srv.SetServerURL(hostname, 443)
 
-	if srv.ServerURL() != testURL {
-		t.Errorf("ServerURL() = %s, want %s", srv.ServerURL(), testURL)
+	if srv.ServerURL() != "https://test.example.com" {
+		t.Errorf("ServerURL() = %s, want %s", srv.ServerURL(), "https://test.example.com")
 	}
 }
 
@@ -254,5 +254,40 @@ func TestAuthRequestFields(t *testing.T) {
 
 	if len(ar.Scopes) != 2 {
 		t.Errorf("Scopes count = %d, want 2", len(ar.Scopes))
+	}
+}
+
+// TestRealishEmail tests the emalish values have the server's
+// hostname appended to them.
+// See: issue #58
+func TestRealishEmail(t *testing.T) {
+	srv := &IDPServer{
+		hostname: "test.ts.net",
+	}
+
+	tests := []struct {
+		name     string
+		email    string
+		expected string
+	}{
+		{
+			name:     "github email",
+			email:    "test@github",
+			expected: "test@github.test.ts.net",
+		},
+		{
+			name:     "passkey email",
+			email:    "test@passkey",
+			expected: "test@passkey.test.ts.net",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := srv.realishEmail(tt.email)
+			if result != tt.expected {
+				t.Errorf("realishEmail() = %v, want %v", result, tt.expected)
+			}
+		})
 	}
 }

--- a/server/token.go
+++ b/server/token.go
@@ -47,8 +47,11 @@ type tailscaleClaims struct {
 	NodeName   string                    `json:"node"`            // name of the node
 	Tailnet    string                    `json:"tailnet"`         // tailnet (like tail-scale.ts.net)
 
-	// Email is the "emailish" value with an '@' sign. It might not be a valid email.
-	Email  string         `json:"email,omitempty"` // user emailish (like "alice@github" or "bob@example.com")
+	// Email is the "emailish" value with an '@' sign. Emailish values like user@github or user@passkey
+	// will have the tsidp instance's hostname appened to them.
+	// Example: user@github becomes user@github.<tsidp-hostname>.<tsname>.ts.net
+	// Example: user@passkey becomes user@passkey.<tsidp-hostname>.<tsname>.ts.net
+	Email  string         `json:"email,omitempty"`
 	UserID tailcfg.UserID `json:"uid,omitempty"`
 
 	// PreferredUsername is the local part of Email (without '@' and domain).
@@ -563,7 +566,7 @@ func (s *IDPServer) issueTokens(w http.ResponseWriter, r *http.Request, ar *Auth
 	for _, scope := range ar.Scopes {
 		switch scope {
 		case "email":
-			tsClaims.Email = who.UserProfile.LoginName
+			tsClaims.Email = s.realishEmail(who.UserProfile.LoginName)
 		case "profile":
 			if username, _, ok := strings.Cut(who.UserProfile.LoginName, "@"); ok {
 				tsClaims.PreferredUsername = username

--- a/server/userinfo.go
+++ b/server/userinfo.go
@@ -90,7 +90,7 @@ func (s *IDPServer) serveUserInfo(w http.ResponseWriter, r *http.Request) {
 	// Always include user profile information if available
 	ui.Name = ar.RemoteUser.UserProfile.DisplayName
 	ui.Picture = ar.RemoteUser.UserProfile.ProfilePicURL
-	ui.Email = ar.RemoteUser.UserProfile.LoginName
+	ui.Email = s.realishEmail(ar.RemoteUser.UserProfile.LoginName)
 	if username, _, ok := strings.Cut(ar.RemoteUser.UserProfile.LoginName, "@"); ok {
 		ui.Username = username
 	}

--- a/tsidp-server.go
+++ b/tsidp-server.go
@@ -175,11 +175,7 @@ func main() {
 		*flagEnableSTS,
 	)
 
-	if *flagPort != 443 {
-		srv.SetServerURL(fmt.Sprintf("https://%s:%d", strings.TrimSuffix(st.Self.DNSName, "."), *flagPort))
-	} else {
-		srv.SetServerURL(fmt.Sprintf("https://%s", strings.TrimSuffix(st.Self.DNSName, ".")))
-	}
+	srv.SetServerURL(strings.TrimSuffix(st.Self.DNSName, "."), *flagPort)
 
 	// Load funnel clients from disk if they exist, regardless of whether funnel is enabled
 	// This ensures OIDC clients persist across restarts


### PR DESCRIPTION
The email claim for github and passkey logins will be expanded into user@passkey.<tsidp-hostname>.<tsname>.ts.net. This is a more valid looking email address to be more pragmatically compatible with clients.

Updates #58