### PR TITLE
server: make nbf < iat to account for client clock skew

### DIFF
--- a/cmd/verifier/verifier.go
+++ b/cmd/verifier/verifier.go
@@ -282,6 +282,30 @@ func main() {
 		fmt.Printf("❌ Error verifying ID Token: %v\n", err)
 		os.Exit(1)
 	}
+
+	iat, ok := idTokenClaims["iat"].(float64)
+	if !ok {
+		fmt.Printf("❌ Error: invalid 'iat' claim.: %v\n", err)
+		os.Exit(1)
+	}
+	exp, ok := idTokenClaims["exp"].(float64)
+	if !ok {
+		fmt.Printf("❌ Error: invalid 'exp' claim.: %v\n", err)
+		os.Exit(1)
+	}
+	nbf, ok := idTokenClaims["nbf"].(float64)
+	if !ok {
+		fmt.Printf("❌ Error: invalid 'nbf' claim.: %v\n", err)
+		os.Exit(1)
+	}
+
+	if !(nbf < iat && iat < exp) {
+		fmt.Printf("❌ Error: ID token expiry times invalid: nbf (%v) < iat (%v) < exp(%v)\n",
+			int(nbf), int(iat), int(exp),
+		)
+		os.Exit(1)
+	}
+
 	if sub, ok := idTokenClaims["sub"].(string); ok {
 		fmt.Printf("✅ Success. ID Token is valid. User Subject (sub): %s\n", sub)
 	} else {

--- a/server/server.go
+++ b/server/server.go
@@ -66,7 +66,6 @@ type IDPServer struct {
 }
 
 // AuthRequest represents an authorization request
-// Migrated from legacy/tsidp.go:325-387
 type AuthRequest struct {
 	// localRP is true if the request is from a relying party running on the
 	// same machine as the idp server. It is mutually exclusive with rpNodeID
@@ -116,6 +115,12 @@ type AuthRequest struct {
 	// validTill is the time until which the token is valid.
 	// Authorization codes expire after 5 minutes per OAuth 2.0 best practices (RFC 6749 recommends max 10 minutes).
 	ValidTill time.Time
+
+	// IssuedAt is the time when the token was issued
+	IssuedAt time.Time
+
+	// NotValidBefore is the time before which the token is not valid yet
+	NotValidBefore time.Time
 
 	// jti is the unique identifier for the JWT token (JWT ID).
 	// This is used for token introspection to return the jti claim.


### PR DESCRIPTION
Set the nbf (not before) claim to be a 5 minutes before the iat (issued at) claim to account for clock skew between tsidp and clients.

Fixes #73