### PR TITLE
.github/flake/go.mod.sri/update-flake.sh: update Nix dependencies

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -27,5 +27,9 @@ jobs:
       run: |
         gofmt -l .
 
-    - name: Run go test
-      run: make test
+    - name: check nix flake is up to date
+      run: |
+        ./update-flake.sh
+        echo
+        echo
+        git diff --name-only --exit-code || (echo "The files above need updating. Please run './update-flake.sh'."; exit 1)

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1758277210,
-        "narHash": "sha256-iCGWf/LTy+aY0zFu8q12lK8KuZp7yvdhStehhyX1v8w=",
+        "lastModified": 1761672384,
+        "narHash": "sha256-o9KF3DJL7g7iYMZq9SWgfS1BFlNbsm6xplRjVlOCkXI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8eaee110344796db060382e15d3af0a9fc396e0e",
+        "rev": "08dacfca559e1d7da38f3cf05f1f45ee9bfd213c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -14,28 +14,7 @@
     }:
     let
       goVersion = "1.24.7";
-      goHash = "sha256-Ko9Q2w+IgDYHxQ1+qINNy3vUg8a0KKkeNg/fhiS0ZGQ=";
-      eachSystem =
-        f:
-        nixpkgs.lib.genAttrs (import systems) (
-          system:
-          f (
-            import nixpkgs {
-              inherit system;
-              overlays = [
-                (final: prev: {
-                  go_1_24 = prev.go_1_24.overrideAttrs {
-                    version = goVersion;
-                    src = prev.fetchurl {
-                      url = "https://go.dev/dl/go${goVersion}.src.tar.gz";
-                      hash = goHash;
-                    };
-                  };
-                })
-              ];
-            }
-          )
-        );
+      eachSystem = f: nixpkgs.lib.genAttrs (import systems) (s: f nixpkgs.legacyPackages.${s});
     in
     {
       formatter = eachSystem (pkgs: pkgs.nixfmt-tree);
@@ -58,7 +37,7 @@
               "-X tailscale.com/version.longStamp=${tsVersion}"
               "-X tailscale.com/version.shortStamp=${tsVersion}"
             ];
-          vendorHash = "sha256-obtcJTg7V4ij3fGVmZMD7QQwKJX6K5PPslpM1XKCk9Q="; # SHA based on vendoring go.mod
+          vendorHash = pkgs.lib.fileContents ./go.mod.sri;
         };
 
         default = self.packages.${pkgs.system}.tsidp;

--- a/go.mod.sri
+++ b/go.mod.sri
@@ -1,0 +1,1 @@
+sha256-iBy+osK+2LdkTzXhrkSaB6nWpUCpr8VkxJTtcfVCFuw=

--- a/update-flake.sh
+++ b/update-flake.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Updates SRI hashes for flake.nix.
+
+set -eu
+
+OUT=$(mktemp -d -t nar-hash-XXXXXX)
+rm -rf "$OUT"
+
+go mod vendor -o "$OUT"
+go run tailscale.com/cmd/nardump --sri "$OUT" >go.mod.sri
+rm -rf "$OUT"


### PR DESCRIPTION
Since not using an unreleased go version, remove custom build of go. 
Add a CI check for go.mod updates for flake.nix
Add script go generate go.mod.sri
Update nixpkgs to pick up new go version.