### PR TITLE
server: constant time code verifier comparisons

### DIFF
--- a/server/token.go
+++ b/server/token.go
@@ -775,7 +775,7 @@ func validateCodeVerifier(verifier, challenge, method string) error {
 		return err
 	}
 
-	if generatedChallenge != challenge {
+	if subtle.ConstantTimeCompare([]byte(generatedChallenge), []byte(challenge)) != 1 {
 		return fmt.Errorf("invalid code_verifier")
 	}
 


### PR DESCRIPTION
Use secure constant time comparisons when validating code challenges.

Signed-off-by: Patrick O'Doherty <p@trickod.com>