### PR TITLE
go.mod: bump to 1.24.9

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.24.8'
+        go-version: '1.24.9'
 
     # Only run in this linux based runner
     - name: Check Formatting

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tailscale/tsidp
 
-go 1.24.8
+go 1.24.9
 
 require (
 	filippo.io/csrf v0.2.1


### PR DESCRIPTION
Fix the remaining vuln in crypto/x509

Updates #97