### PR TITLE
Only print funnel message when funnelOn is true

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -456,7 +456,9 @@ func ServeOnLocalTailscaled(ctx context.Context, lc *local.Client, st *ipnstate.
 	foregroundSc := new(ipn.ServeConfig)
 	mak.Set(&sc.Foreground, n.SessionID, foregroundSc)
 	serverURL := strings.TrimSuffix(st.Self.DNSName, ".")
-	fmt.Printf("setting funnel for %s:%v\n", serverURL, dstPort)
+	if shouldFunnel {
+		fmt.Printf("setting funnel for %s:%v\n", serverURL, dstPort)
+	}
 
 	foregroundSc.SetFunnel(serverURL, dstPort, shouldFunnel)
 	foregroundSc.SetWebHandler(&ipn.HTTPHandler{


### PR DESCRIPTION
Fixes #91.

~Also adds `.direnv` and `.envrc` to the `.gitignore`. These are quite common with nix shells. While `.direnv` certainly shouldn't be added. `.envrc` is more debatable but personally I lean on the side that they shouldn't be committed.~
> Extracted to https://github.com/tailscale/tsidp/pull/130