### PR TITLE
.gitignore: ignore .direnv and .envrc files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ server/oidc-key.json
 oidc-key.json
 oidc-funnel-clients.json
 result
+
+# direnv files
+.envrc
+.direnv


### PR DESCRIPTION
Adds `.direnv` and `.envrc` to the `.gitignore`. These are quite common with nix shells. While `.direnv` certainly shouldn't be added. `.envrc` is more debatable but personally I lean on the side that they shouldn't be committed.