### PR TITLE
go.mod: update go to 1.24.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tailscale/tsidp
 
-go 1.24.9
+go 1.24.11
 
 require (
 	filippo.io/csrf v0.2.1


### PR DESCRIPTION
Includes security fixes to the crypto/x509 package and address https://github.com/tailscale/tsidp/actions/runs/19893269555