### PR TITLE
.github,Dockerfile: pin alpine container to fix build issues

### DIFF
--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -7,14 +7,19 @@ permissions:
 on:
   push:
     tags:
-      - '*'
+      - "*"
 
   # Allows manual triggering of the workflow
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag release (e.g. v1.2.3)'
+        description: "Tag release (e.g. v1.2.3)"
         required: true
+      push:
+        description: "Push to registry"
+        required: false
+        type: boolean
+        default: false
 
   # allow for testing of PR updating this file
   pull_request:
@@ -22,7 +27,7 @@ on:
       - ".github/workflows/containers.yaml"
 
 jobs:
-  build-and-push:
+  build-and-maybe-push:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -68,6 +73,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
+          # only push on tags or manually triggered with inputs.push set
+          push: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push) }}
           tags: ${{ steps.image_tags.outputs.tags }}
           platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
     go build -a -installsuffix cgo -o tsidp-server .
 
 # Final stage
-FROM --platform=$TARGETPLATFORM alpine:latest
+FROM --platform=$TARGETPLATFORM alpine:3.22
 RUN apk --no-cache add ca-certificates
 WORKDIR /app
 


### PR DESCRIPTION
Address build issues with container with `alpine:latest`  (v3.23) by pinning to using `alpine:3.22`