### PR TITLE
go.mod: Updated to use newer go as identified by govulncheck.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tailscale/tsidp
 
-go 1.24.12
+go 1.24.13
 
 require (
 	filippo.io/csrf v0.2.1


### PR DESCRIPTION
Unit tests still appear to pass.  I'm not able to run govulncheck without panicking locally so will address further action items as the github-running govulncheck finds them.