### PR TITLE
server: redact client secret from authentication error messages

### DIFF
--- a/server/token.go
+++ b/server/token.go
@@ -920,7 +920,7 @@ func (ar *AuthRequest) allowRelyingParty(r *http.Request) (int, error) {
 		return http.StatusBadRequest, fmt.Errorf("tsidp: client_id mismatch")
 	}
 	if clientSecretcmp != 1 {
-		return http.StatusUnauthorized, fmt.Errorf("tsidp: invalid client secret: [%s] [%s]", clientID, clientSecret)
+		return http.StatusUnauthorized, fmt.Errorf("tsidp: invalid client secret for client %q", clientID)
 	}
 	return http.StatusOK, nil
 }


### PR DESCRIPTION
## Summary

The `allowRelyingParty` function in `server/token.go` includes the plaintext client secret in the error message when client authentication fails:

```go
return http.StatusUnauthorized, fmt.Errorf("tsidp: invalid client secret: [%s] [%s]", clientID, clientSecret)
```

This leaks credentials into server logs via `writeHTTPError` → `slog.Warn`. In containerised deployments where logs are aggregated into centralised platforms, this creates a credential exposure vector.

## Change

Replace the secret with only the client ID, which is sufficient for debugging authentication failures:

```go
return http.StatusUnauthorized, fmt.Errorf("tsidp: invalid client secret for client %q", clientID)
```

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all existing tests)
- [x] `go vet ./...` clean
- [x] `gofmt -l .` produces no output