### PR TITLE
Add --version flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,17 @@
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+LDFLAGS := -ldflags="-s -w -X main.version=$(VERSION)"
+
 .PHONY: build build-osx build-linux test clean docker-image
 
 build: build-osx build-linux
 
 build-osx:
 	@mkdir -p build
-	GOOS=darwin GOARCH=arm64 go build -o build/tsidp-server-darwin-arm64-$(shell date +%Y-%m-%d)-$(shell git rev-parse --short=5 HEAD) ./tsidp-server.go
+	GOOS=darwin GOARCH=arm64 go build $(LDFLAGS) -o build/tsidp-server-darwin-arm64-$(shell date +%Y-%m-%d)-$(shell git rev-parse --short=5 HEAD) ./tsidp-server.go
 
 build-linux:
 	@mkdir -p build
-	GOOS=linux GOARCH=amd64 go build -o build/tsidp-server-linux-amd64-$(shell date +%Y-%m-%d)-$(shell git rev-parse --short=5 HEAD) ./tsidp-server.go
+	GOOS=linux GOARCH=amd64 go build $(LDFLAGS) -o build/tsidp-server-linux-amd64-$(shell date +%Y-%m-%d)-$(shell git rev-parse --short=5 HEAD) ./tsidp-server.go
 
 docker-image:
 	docker build -t tsidp:latest .

--- a/tsidp-server.go
+++ b/tsidp-server.go
@@ -35,6 +35,9 @@ import (
 	"tailscale.com/version"
 )
 
+// version is set at build time via -ldflags "-X main.version=..."
+var version = "dev"
+
 // Command line flags
 var (
 	flagPort               = flag.Int("port", envIntOr("TSIDP_PORT", 443), "port to listen on")
@@ -56,6 +59,11 @@ var (
 // main initializes and starts the tsidp server
 func main() {
 	ctx := context.Background()
+
+	if len(os.Args) == 2 && os.Args[1] == "--version" {
+		fmt.Println(version)
+		os.Exit(0)
+	}
 
 	flag.Parse()
 	switch *flagLogLevel {


### PR DESCRIPTION
Adds a `version` variable set at build time via ldflags and a `--version` flag that prints it and exits.

- `var version = "dev"` default, overridden by `-X main.version=...`
- Checked before `flag.Parse()` so it doesn't conflict with the flag package
- Makefile passes `-X main.version=$(VERSION)` using `git describe`