### PR TITLE
feat: add `--version` flag and version resolution to CLI

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -38,3 +38,10 @@ jobs:
       run: |
         go build ./...
         go test -v ./...
+
+    - name: Verify --version flag
+      run: |
+        go build -o tsidp-server .
+        VERSION=$(./tsidp-server --version)
+        echo "Version: $VERSION"
+        [ -n "$VERSION" ] || { echo "ERROR: --version produced empty output"; exit 1; }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,3 +51,15 @@ jobs:
           args: ${{ steps.goreleaser-args.outputs.args }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Verify --version flag
+        run: |
+          BINARY=$(find dist -path '*linux*amd64*' -name 'tsidp' -type f | head -1)
+          [ -n "$BINARY" ] || { echo "ERROR: could not find linux/amd64 binary in dist/"; exit 1; }
+          VERSION=$("$BINARY" --version)
+          echo "Version: $VERSION"
+          [ -n "$VERSION" ] || { echo "ERROR: --version produced empty output"; exit 1; }
+          if [ "${GITHUB_EVENT_NAME}" != "pull_request" ]; then
+            EXPECTED="${GITHUB_REF_NAME}"
+            [ "$VERSION" = "$EXPECTED" ] || { echo "ERROR: expected $EXPECTED got $VERSION"; exit 1; }
+          fi

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,6 +3,9 @@ version: 2
 builds:
   - env:
       - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+      - -X github.com/tailscale/tsidp/server.version={{.Version}}
     goos:
       - linux
       - darwin

--- a/server/version.go
+++ b/server/version.go
@@ -1,0 +1,31 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package server
+
+import "runtime/debug"
+
+// version is set at build time via ldflags:
+// go build -ldflags "-X github.com/tailscale/tsidp/server.version=v1.2.3"
+var version string
+
+// GetVersion returns the version string for tsidp.
+// Priority: ldflag-injected tag > VCS short hash > "dev".
+func GetVersion() string { return cachedVersion }
+
+var cachedVersion = func() string {
+	if version != "" {
+		return version
+	}
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, s := range info.Settings {
+			if s.Key == "vcs.revision" && s.Value != "" {
+				if len(s.Value) > 7 {
+					return s.Value[:7]
+				}
+				return s.Value
+			}
+		}
+	}
+	return "dev"
+}()

--- a/tsidp-server.go
+++ b/tsidp-server.go
@@ -52,6 +52,8 @@ var (
 	// extended debugging information
 	flagDebugAllRequests = flag.Bool("debug-all-requests", envknob.Bool("TSIDP_DEBUG_ALL_REQUESTS"), "capture and print all HTTP requests and responses")
 	flagDebugTSNet       = flag.Bool("debug-tsnet", envknob.Bool("TSIDP_DEBUG_TSNET"), "enable tsnet.Server logging")
+
+	flagVersion = flag.Bool("version", false, "print version and exit")
 )
 
 // main initializes and starts the tsidp server
@@ -59,6 +61,10 @@ func main() {
 	ctx := context.Background()
 
 	flag.Parse()
+	if *flagVersion {
+		fmt.Println(server.GetVersion())
+		os.Exit(0)
+	}
 	switch *flagLogLevel {
 	case "debug":
 		slog.SetLogLoggerLevel(slog.LevelDebug)


### PR DESCRIPTION
* Add `GetVersion()` with fallback chain: ldflag tag > git short hash > "dev".
* Wire goreleaser to inject version at build time via ldflags.
* Add `--version` CLI flag for programmatic version checks.

Relates to #157