### PR TITLE
oidc: advertise token_endpoint_auth_methods_supported in discovery

### DIFF
--- a/server/oauth-metadata.go
+++ b/server/oauth-metadata.go
@@ -14,20 +14,21 @@ import (
 
 // openIDProviderMetadata is a partial representation of OpenID Provider Metadata.
 type openIDProviderMetadata struct {
-	Issuer                           string              `json:"issuer"`
-	AuthorizationEndpoint            string              `json:"authorization_endpoint,omitempty"`
-	TokenEndpoint                    string              `json:"token_endpoint,omitempty"`
-	UserInfoEndpoint                 string              `json:"userinfo_endpoint,omitempty"`
-	IntrospectionEndpoint            string              `json:"introspection_endpoint,omitempty"`
-	RegistrationEndpoint             string              `json:"registration_endpoint,omitempty"`
-	JWKS_URI                         string              `json:"jwks_uri"`
-	ScopesSupported                  views.Slice[string] `json:"scopes_supported"`
-	ResponseTypesSupported           views.Slice[string] `json:"response_types_supported"`
-	SubjectTypesSupported            views.Slice[string] `json:"subject_types_supported"`
-	ClaimsSupported                  views.Slice[string] `json:"claims_supported"`
-	IDTokenSigningAlgValuesSupported views.Slice[string] `json:"id_token_signing_alg_values_supported"`
-	GrantTypesSupported              views.Slice[string] `json:"grant_types_supported,omitempty"`
-	CodeChallengeMethodsSupported    views.Slice[string] `json:"code_challenge_methods_supported,omitempty"`
+	Issuer                            string              `json:"issuer"`
+	AuthorizationEndpoint             string              `json:"authorization_endpoint,omitempty"`
+	TokenEndpoint                     string              `json:"token_endpoint,omitempty"`
+	UserInfoEndpoint                  string              `json:"userinfo_endpoint,omitempty"`
+	IntrospectionEndpoint             string              `json:"introspection_endpoint,omitempty"`
+	RegistrationEndpoint              string              `json:"registration_endpoint,omitempty"`
+	JWKS_URI                          string              `json:"jwks_uri"`
+	ScopesSupported                   views.Slice[string] `json:"scopes_supported"`
+	ResponseTypesSupported            views.Slice[string] `json:"response_types_supported"`
+	SubjectTypesSupported             views.Slice[string] `json:"subject_types_supported"`
+	ClaimsSupported                   views.Slice[string] `json:"claims_supported"`
+	IDTokenSigningAlgValuesSupported  views.Slice[string] `json:"id_token_signing_alg_values_supported"`
+	GrantTypesSupported               views.Slice[string] `json:"grant_types_supported,omitempty"`
+	TokenEndpointAuthMethodsSupported views.Slice[string] `json:"token_endpoint_auth_methods_supported,omitempty"`
+	CodeChallengeMethodsSupported     views.Slice[string] `json:"code_challenge_methods_supported,omitempty"`
 }
 
 // oauthAuthorizationServerMetadata is a representation of
@@ -95,18 +96,19 @@ func (s *IDPServer) serveOpenIDConfig(w http.ResponseWriter, r *http.Request) {
 	je := json.NewEncoder(w)
 	je.SetIndent("", "  ")
 	metadata := openIDProviderMetadata{
-		AuthorizationEndpoint:            s.serverURL + "/authorize",
-		Issuer:                           s.serverURL,
-		JWKS_URI:                         s.serverURL + "/.well-known/jwks.json",
-		UserInfoEndpoint:                 s.serverURL + "/userinfo",
-		TokenEndpoint:                    s.serverURL + "/token",
-		IntrospectionEndpoint:            s.serverURL + "/introspect",
-		ScopesSupported:                  openIDSupportedScopes,
-		ResponseTypesSupported:           openIDSupportedReponseTypes,
-		SubjectTypesSupported:            openIDSupportedSubjectTypes,
-		ClaimsSupported:                  openIDSupportedClaims,
-		IDTokenSigningAlgValuesSupported: openIDSupportedSigningAlgos,
-		CodeChallengeMethodsSupported:    pkceCodeChallengeMethodsSupported,
+		AuthorizationEndpoint:             s.serverURL + "/authorize",
+		Issuer:                            s.serverURL,
+		JWKS_URI:                          s.serverURL + "/.well-known/jwks.json",
+		UserInfoEndpoint:                  s.serverURL + "/userinfo",
+		TokenEndpoint:                     s.serverURL + "/token",
+		IntrospectionEndpoint:             s.serverURL + "/introspect",
+		ScopesSupported:                   openIDSupportedScopes,
+		ResponseTypesSupported:            openIDSupportedReponseTypes,
+		SubjectTypesSupported:             openIDSupportedSubjectTypes,
+		ClaimsSupported:                   openIDSupportedClaims,
+		IDTokenSigningAlgValuesSupported:  openIDSupportedSigningAlgos,
+		CodeChallengeMethodsSupported:     pkceCodeChallengeMethodsSupported,
+		TokenEndpointAuthMethodsSupported: oauthSupportedTokenEndpointAuthMethods,
 	}
 
 	// Add grant types supported

--- a/server/oauth-metadata_test.go
+++ b/server/oauth-metadata_test.go
@@ -244,6 +244,64 @@ func TestPKCEMetadata(t *testing.T) {
 	}
 }
 
+// TestTokenEndpointAuthMethods tests that token_endpoint_auth_methods_supported
+// is present in both discovery endpoints.
+func TestTokenEndpointAuthMethods(t *testing.T) {
+	s := &IDPServer{
+		serverURL:   "https://idp.test.ts.net",
+		loopbackURL: "http://localhost:8080",
+	}
+
+	tests := []struct {
+		name     string
+		endpoint string
+		serveFn  func(http.ResponseWriter, *http.Request)
+	}{
+		{
+			name:     "OpenID Connect metadata",
+			endpoint: "/.well-known/openid-configuration",
+			serveFn:  s.serveOpenIDConfig,
+		},
+		{
+			name:     "OAuth 2.0 metadata",
+			endpoint: "/.well-known/oauth-authorization-server",
+			serveFn:  s.serveOAuthMetadata,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tt.endpoint, nil)
+			req.RemoteAddr = "127.0.0.1:12345"
+			rr := httptest.NewRecorder()
+			tt.serveFn(rr, req)
+
+			var metadata map[string]any
+			if err := json.Unmarshal(rr.Body.Bytes(), &metadata); err != nil {
+				t.Fatalf("failed to unmarshal metadata: %v", err)
+			}
+
+			methods, ok := metadata["token_endpoint_auth_methods_supported"].([]any)
+			if !ok {
+				t.Fatal("token_endpoint_auth_methods_supported not found or wrong type")
+			}
+
+			methodSet := make(map[string]bool)
+			for _, m := range methods {
+				if s, ok := m.(string); ok {
+					methodSet[s] = true
+				}
+			}
+			if !methodSet["client_secret_basic"] {
+				t.Error("expected client_secret_basic in token_endpoint_auth_methods_supported")
+			}
+			if !methodSet["client_secret_post"] {
+				t.Error("expected client_secret_post in token_endpoint_auth_methods_supported")
+			}
+		})
+	}
+}
+
 // TestMetadataSTSSupport tests that STS token exchange grant is properly advertised when enabled
 func TestMetadataSTSSupport(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Fixes #143.

TSIDP's OIDC discovery document currently omits `token_endpoint_auth_methods_supported`, which breaks interoperability with clients (e.g. NextAuth) that rely on discovery metadata to determine how to authenticate to the
token endpoint.

This change adds:
  "token_endpoint_auth_methods_supported" to `/.well-known/openid-configuration`, matching the token endpoint’s supported authentication method.

Notes:
- This aligns TSIDP with OIDC discovery expectations and improves client compatibility.
- Discovery document now includes the new field and tests updated        

Signed-off-by: Marc Manza  <marc@tailscale.com>>   