### PR TITLE
enable adding custom scopes to access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ The `tsidp-server` is configured by several command-line flags:
 | `-log <level>`                 | Set logging level: `debug`, `info`, `warn`, `error`                                                | `info`   |
 | `-debug-all-requests`          | For development. Prints all requests and responses                                                 | disabled |
 | `-debug-tsnet`                 | For development. Enables debug level logging with tsnet connection                                 | disabled |
+| `-additional-scopes`           | Advertises additional scopes that are supported for the access token, space separated              | `""`     |
 
 ### CLI Environment Variables
 
@@ -207,6 +208,7 @@ The Docker image exposes the CLI flags through environment variables. If omitted
 | `TSIDP_DEBUG_ALL_REQUESTS=1`             | `-debug-all-requests`      |
 | `TS_AUTHKEY=<key>`                       | _(env var only)_           |
 | `TS_ADVERTISE_TAGS=<tags>`               | `-advertise-tags <tags>`   |
+| `TSIDP_ADDITIONAL_SCOPES="<scopes>"`     | `-additional-scopes`       |
 
 ## Application Configuration Guides (WIP)
 

--- a/server/authorize.go
+++ b/server/authorize.go
@@ -159,7 +159,7 @@ func (s *IDPServer) validateScopes(requestedScopes []string) ([]string, error) {
 	}
 
 	validatedScopes := make([]string, 0, len(requestedScopes))
-	supportedScopes := openIDSupportedScopes.AsSlice()
+	supportedScopes := s.supportedScopes.AsSlice()
 
 	for _, scope := range requestedScopes {
 		if supported := slices.Contains(supportedScopes, scope); !supported {
@@ -169,6 +169,36 @@ func (s *IDPServer) validateScopes(requestedScopes []string) ([]string, error) {
 	}
 
 	return validatedScopes, nil
+}
+
+// mergeScopeClaim merges a JWT "scope" claim value (a space-delimited string or
+// a slice of scope strings) into existing scopes, de-duplicating and preserving order.
+func mergeScopeClaim(existing []string, raw any) []string {
+	var incoming []string
+	switch v := raw.(type) {
+	case string:
+		incoming = strings.Fields(v)
+	case []string:
+		incoming = v
+	case []any:
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				incoming = append(incoming, s)
+			}
+		}
+	case nil:
+		incoming = make([]string, 0)
+	}
+	result := make([]string, 0, len(existing))
+	openIDScopes := openIDSupportedScopes.AsSlice()
+
+	for _, scope := range existing {
+		if slices.Contains(incoming, scope) || slices.Contains(openIDScopes, scope) {
+			result = append(result, scope)
+		}
+	}
+
+	return result
 }
 
 // redirectAuthError redirects to the client's redirect_uri with error parameters

--- a/server/authorize.go
+++ b/server/authorize.go
@@ -171,29 +171,30 @@ func (s *IDPServer) validateScopes(requestedScopes []string) ([]string, error) {
 	return validatedScopes, nil
 }
 
-// mergeScopeClaim merges a JWT "scope" claim value (a space-delimited string or
-// a slice of scope strings) into existing scopes, de-duplicating and preserving order.
-func mergeScopeClaim(existing []string, raw any) []string {
-	var incoming []string
+// validateRequestedScopes checks requested scopes against a JWT "scope" claim value
+// (a space-delimited string or a slice of scope strings)
+// returning a de-duplicated slice of allowed scopes, preserving order.
+func validateRequestedScopes(requested []string, raw any) []string {
+	var allowed []string
 	switch v := raw.(type) {
 	case string:
-		incoming = strings.Fields(v)
+		allowed = strings.Fields(v)
 	case []string:
-		incoming = v
+		allowed = v
 	case []any:
 		for _, item := range v {
 			if s, ok := item.(string); ok {
-				incoming = append(incoming, s)
+				allowed = append(allowed, s)
 			}
 		}
 	case nil:
-		incoming = make([]string, 0)
+		allowed = make([]string, 0)
 	}
-	result := make([]string, 0, len(existing))
-	openIDScopes := openIDSupportedScopes.AsSlice()
+	result := make([]string, 0, len(requested))
+	allowed = append(allowed, openIDSupportedScopes.AsSlice()...)
 
-	for _, scope := range existing {
-		if slices.Contains(incoming, scope) || slices.Contains(openIDScopes, scope) {
+	for _, scope := range requested {
+		if slices.Contains(allowed, scope) && !slices.Contains(result, scope) {
 			result = append(result, scope)
 		}
 	}

--- a/server/authorize_test.go
+++ b/server/authorize_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -238,6 +239,48 @@ func TestValidateScopes(t *testing.T) {
 				if i < len(tt.expectedScopes) && scope != tt.expectedScopes[i] {
 					t.Errorf("expected scope[%d] = %q, got %q", i, tt.expectedScopes[i], scope)
 				}
+			}
+		})
+	}
+}
+
+func TestValidateRequestedScopes(t *testing.T) {
+	tests := []struct {
+		name            string
+		requestedScopes []string
+		allowedScopes   []string
+		expectedOutput  []string
+	}{
+		{
+			name:            "standard oauth scopes",
+			requestedScopes: []string{"openid", "email", "profile"},
+			allowedScopes:   []string{},
+			expectedOutput:  []string{"openid", "email", "profile"},
+		},
+		{
+			name:            "additional not allowed scope",
+			requestedScopes: []string{"openid", "email", "profile", "admin"},
+			allowedScopes:   []string{},
+			expectedOutput:  []string{"openid", "email", "profile"},
+		},
+		{
+			name:            "additional allowed scope",
+			requestedScopes: []string{"openid", "email", "profile", "admin"},
+			allowedScopes:   []string{"admin"},
+			expectedOutput:  []string{"openid", "email", "profile", "admin"},
+		},
+		{
+			name:            "duplicate allowed scopes",
+			requestedScopes: []string{"openid", "openid", "openid"},
+			allowedScopes:   nil,
+			expectedOutput:  []string{"openid"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := validateRequestedScopes(tt.requestedScopes, tt.allowedScopes)
+			if !slices.Equal(result, tt.expectedOutput) {
+				t.Errorf("expected result: %q, got: %q", tt.expectedOutput, result)
 			}
 		})
 	}

--- a/server/authorize_test.go
+++ b/server/authorize_test.go
@@ -55,11 +55,12 @@ func TestScopeHandling(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &IDPServer{
-				serverURL:     "https://idp.test.ts.net",
-				code:          make(map[string]*AuthRequest),
-				accessToken:   make(map[string]*AuthRequest),
-				refreshToken:  make(map[string]*AuthRequest),
-				funnelClients: make(map[string]*FunnelClient),
+				serverURL:       "https://idp.test.ts.net",
+				code:            make(map[string]*AuthRequest),
+				accessToken:     make(map[string]*AuthRequest),
+				refreshToken:    make(map[string]*AuthRequest),
+				funnelClients:   make(map[string]*FunnelClient),
+				supportedScopes: openIDSupportedScopes,
 			}
 
 			// Set up funnel client
@@ -174,7 +175,7 @@ func TestScopeHandling(t *testing.T) {
 // TestValidateScopes tests the validateScopes function directly
 // This provides more focused unit testing of scope validation logic
 func TestValidateScopes(t *testing.T) {
-	s := &IDPServer{}
+	s := &IDPServer{supportedScopes: openIDSupportedScopes}
 
 	tests := []struct {
 		name           string

--- a/server/oauth-metadata.go
+++ b/server/oauth-metadata.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"slices"
 
 	"gopkg.in/square/go-jose.v2"
 	"tailscale.com/types/views"
@@ -79,6 +80,18 @@ var (
 	pkceCodeChallengeMethodsSupported = views.SliceOf([]string{"plain", "S256"})
 )
 
+func mergeScopes(existing, additionalScopes []string) views.Slice[string] {
+	merged := append([]string{}, existing...)
+
+	for _, scope := range additionalScopes {
+		if scope != "" && !slices.Contains(merged, scope) {
+			merged = append(merged, scope)
+		}
+	}
+	return views.SliceOf(merged)
+
+}
+
 // serveOpenIDConfig serves the OpenID Connect discovery endpoint
 func (s *IDPServer) serveOpenIDConfig(w http.ResponseWriter, r *http.Request) {
 	h := w.Header()
@@ -102,7 +115,7 @@ func (s *IDPServer) serveOpenIDConfig(w http.ResponseWriter, r *http.Request) {
 		UserInfoEndpoint:                  s.serverURL + "/userinfo",
 		TokenEndpoint:                     s.serverURL + "/token",
 		IntrospectionEndpoint:             s.serverURL + "/introspect",
-		ScopesSupported:                   openIDSupportedScopes,
+		ScopesSupported:                   s.supportedScopes,
 		ResponseTypesSupported:            openIDSupportedReponseTypes,
 		SubjectTypesSupported:             openIDSupportedSubjectTypes,
 		ClaimsSupported:                   openIDSupportedClaims,
@@ -159,7 +172,7 @@ func (s *IDPServer) serveOAuthMetadata(w http.ResponseWriter, r *http.Request) {
 		JWKS_URI:                           s.serverURL + "/.well-known/jwks.json",
 		ResponseTypesSupported:             openIDSupportedReponseTypes,
 		GrantTypesSupported:                views.SliceOf(grantTypes),
-		ScopesSupported:                    openIDSupportedScopes,
+		ScopesSupported:                    s.supportedScopes,
 		TokenEndpointAuthMethodsSupported:  oauthSupportedTokenEndpointAuthMethods,
 		ResourceIndicatorsSupported:        true, // RFC 8707 support
 		AuthorizationDetailsTypesSupported: views.SliceOf([]string{"resource_indicators"}),

--- a/server/oauth-metadata_test.go
+++ b/server/oauth-metadata_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -463,6 +464,29 @@ func TestMetadataCORSHeaders(t *testing.T) {
 
 			if accessControlAllowHeaders != "*" {
 				t.Errorf("expected AccessControl-Allow-Headers to be '*', got %s", accessControlAllowHeaders)
+			}
+		})
+	}
+}
+
+func TestMergeScopes(t *testing.T) {
+	tests := []struct {
+		name       string
+		existing   []string
+		additional []string
+		expected   []string
+	}{
+		{name: "with empty additional", existing: []string{"openid"}, additional: []string{}, expected: []string{"openid"}},
+		{name: "with empty string in additional", existing: []string{"openid"}, additional: []string{""}, expected: []string{"openid"}},
+		{name: "with duplicate in additional", existing: []string{"openid"}, additional: []string{"openid"}, expected: []string{"openid"}},
+		{name: "with additional", existing: []string{"openid"}, additional: []string{"email", "profile"}, expected: []string{"openid", "email", "profile"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := mergeScopes(tt.existing, tt.additional)
+			if !slices.Equal(result.AsSlice(), tt.expected) {
+				t.Errorf("expected: %q, got: %q", tt.expected, result)
 			}
 		})
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -33,6 +33,7 @@ import (
 	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/lazy"
+	"tailscale.com/types/views"
 	"tailscale.com/util/mak"
 )
 
@@ -59,6 +60,8 @@ type IDPServer struct {
 	accessToken   map[string]*AuthRequest  // keyed by random hex
 	refreshToken  map[string]*AuthRequest  // keyed by random hex
 	funnelClients map[string]*FunnelClient // keyed by client ID
+
+	supportedScopes views.Slice[string]
 
 	// for bypassing application capability checks for testing
 	// see issue #44
@@ -165,15 +168,16 @@ const (
 // New creates a new IDPServer instance
 func New(lc *local.Client, stateDir string, funnel, localTSMode, enableSTS bool) *IDPServer {
 	return &IDPServer{
-		lc:            lc,
-		stateDir:      stateDir,
-		funnel:        funnel,
-		localTSMode:   localTSMode,
-		enableSTS:     enableSTS,
-		code:          make(map[string]*AuthRequest),
-		accessToken:   make(map[string]*AuthRequest),
-		refreshToken:  make(map[string]*AuthRequest),
-		funnelClients: make(map[string]*FunnelClient),
+		lc:              lc,
+		stateDir:        stateDir,
+		funnel:          funnel,
+		localTSMode:     localTSMode,
+		enableSTS:       enableSTS,
+		code:            make(map[string]*AuthRequest),
+		accessToken:     make(map[string]*AuthRequest),
+		refreshToken:    make(map[string]*AuthRequest),
+		funnelClients:   make(map[string]*FunnelClient),
+		supportedScopes: openIDSupportedScopes,
 	}
 }
 
@@ -185,6 +189,10 @@ func (s *IDPServer) SetServerURL(hostname string, port int) {
 	} else {
 		s.serverURL = fmt.Sprintf("https://%s", hostname)
 	}
+}
+
+func (s *IDPServer) SetAdditionalScopes(additionalScopes []string) {
+	s.supportedScopes = mergeScopes(s.supportedScopes.AsSlice(), additionalScopes)
 }
 
 // ServerURL returns the server URL

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -5,6 +5,7 @@ package server
 
 import (
 	"log/slog"
+	"slices"
 	"testing"
 	"time"
 )
@@ -49,6 +50,24 @@ func TestNew(t *testing.T) {
 	if srv.funnelClients == nil {
 		t.Error("funnelClients map not initialized")
 	}
+}
+
+func TestSetAdditionalScopes(t *testing.T) {
+	srv := New(nil, "", false, false, false)
+
+	expectedScopes := []string{"openid", "email", "profile"}
+	supported := srv.supportedScopes.AsSlice()
+	if !slices.Equal(expectedScopes, supported) {
+		t.Errorf("expected: %q, got: %q", expectedScopes, supported)
+
+	}
+	srv.SetAdditionalScopes([]string{"additional", "scopes"})
+	supported = srv.supportedScopes.AsSlice()
+	expectedScopes = append(expectedScopes, []string{"additional", "scopes"}...)
+	if !slices.Equal(supported, expectedScopes) {
+		t.Errorf("expected: %q, got: %q", expectedScopes, supported)
+	}
+
 }
 
 // TestSetServerURL tests setting and getting server URL

--- a/server/token.go
+++ b/server/token.go
@@ -596,6 +596,8 @@ func (s *IDPServer) issueTokens(w http.ResponseWriter, r *http.Request, ar *Auth
 		tsClaimsWithExtra["act"] = ar.ActorInfo
 	}
 
+	ar.Scopes = mergeScopeClaim(ar.Scopes, tsClaimsWithExtra["scope"])
+
 	// Create an OIDC token using this issuer's signer.
 	token, err := jwt.Signed(signer).Claims(tsClaimsWithExtra).CompactSerialize()
 	if err != nil {

--- a/server/token.go
+++ b/server/token.go
@@ -596,7 +596,7 @@ func (s *IDPServer) issueTokens(w http.ResponseWriter, r *http.Request, ar *Auth
 		tsClaimsWithExtra["act"] = ar.ActorInfo
 	}
 
-	ar.Scopes = mergeScopeClaim(ar.Scopes, tsClaimsWithExtra["scope"])
+	ar.Scopes = validateRequestedScopes(ar.Scopes, tsClaimsWithExtra["scope"])
 
 	// Create an OIDC token using this issuer's signer.
 	token, err := jwt.Signed(signer).Claims(tsClaimsWithExtra).CompactSerialize()

--- a/tsidp-server.go
+++ b/tsidp-server.go
@@ -45,6 +45,7 @@ var (
 	flagDir                = flag.String("dir", envknob.String("TS_STATE_DIR"), "tsnet state directory; a default one will be created if not provided")
 	flagEnableSTS          = flag.Bool("enable-sts", envknob.Bool("TSIDP_ENABLE_STS"), "enable OIDC STS token exchange support")
 	flagAdvertiseTags      = flag.String("advertise-tags", envknob.String("TS_ADVERTISE_TAGS"), "comma-separated advertise tags (e.g. tag:tsidp,tag:server); required when using OAuth client secrets")
+	flagAdditionalScopes   = flag.String("additional-scopes", envknob.String("TSIDP_ADDITIONAL_SCOPES"), "space-separated string of additional user defined Oauth scopes in addition to the OpenID defaults (openid, email, profile)")
 
 	// application logging levels
 	flagLogLevel = flag.String("log", cmp.Or(envknob.String("TSIDP_LOG"), "info"), "log levels: debug, info, warn, error")
@@ -198,6 +199,7 @@ func main() {
 		*flagUseLocalTailscaled,
 		*flagEnableSTS,
 	)
+	srv.SetAdditionalScopes(strings.Fields(*flagAdditionalScopes))
 
 	srv.SetServerURL(strings.TrimSuffix(st.Self.DNSName, "."), *flagPort)
 


### PR DESCRIPTION
These changes address one of the problems described in the following issue: https://github.com/tailscale/tsidp/issues/177


This enables users to set any additional scopes to be advertised at the `.well-known/oauth-authorization-server` end point. 

it also uses the scope key in the extraClaims to validate whether the user can be granted the scope.

This solves our particular usecase which is integrating with a 3rd party service that only uses the access token, and not the id token. But i'm happy to make, or for you to make, any changes required to make this appropriate for all users.

I apologise if the code isn't up to standard, i've not written much go and not for about a year, again, happy to make any changes to conform