### PR TITLE
fix: use last xff header instead of first

### DIFF
--- a/server/appcap.go
+++ b/server/appcap.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"net/http"
 	"net/netip"
+	"strings"
 
 	"tailscale.com/client/tailscale/apitype"
 	"tailscale.com/tailcfg"
@@ -80,7 +81,10 @@ func (s *IDPServer) addGrantAccessContext(handler http.HandlerFunc) http.Handler
 
 		var remoteAddr string
 		if s.localTSMode {
-			remoteAddr = r.Header.Get("X-Forwarded-For")
+			xffValues := r.Header.Values("X-Forwarded-For")
+			if len(xffValues) > 0 {
+				remoteAddr = strings.TrimSpace(xffValues[len(xffValues)-1])
+			}
 		} else {
 			remoteAddr = r.RemoteAddr
 		}

--- a/server/appcap.go
+++ b/server/appcap.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"net/http"
 	"net/netip"
-	"strings"
 
 	"tailscale.com/client/tailscale/apitype"
 	"tailscale.com/tailcfg"
@@ -81,10 +80,7 @@ func (s *IDPServer) addGrantAccessContext(handler http.HandlerFunc) http.Handler
 
 		var remoteAddr string
 		if s.localTSMode {
-			xffValues := r.Header.Values("X-Forwarded-For")
-			if len(xffValues) > 0 {
-				remoteAddr = strings.TrimSpace(xffValues[len(xffValues)-1])
-			}
+			remoteAddr = lastForwardedForAddr(r)
 		} else {
 			remoteAddr = r.RemoteAddr
 		}

--- a/server/authorize.go
+++ b/server/authorize.go
@@ -72,7 +72,10 @@ func (s *IDPServer) serveAuthorize(w http.ResponseWriter, r *http.Request) {
 	// Get user information
 	var remoteAddr string
 	if s.localTSMode {
-		remoteAddr = r.Header.Get("X-Forwarded-For")
+		xffValues := r.Header.Values("X-Forwarded-For")
+		if len(xffValues) > 0 {
+			remoteAddr = strings.TrimSpace(xffValues[len(xffValues)-1])
+		}
 	} else {
 		remoteAddr = r.RemoteAddr
 	}

--- a/server/authorize.go
+++ b/server/authorize.go
@@ -17,6 +17,25 @@ import (
 	"tailscale.com/util/rands"
 )
 
+// lastForwardedForAddr returns the client address tsidp should trust from
+// X-Forwarded-For when running against a local tailscaled (localTSMode).
+// The last header is used since tailscaled is always the last proxy in this mode.
+func lastForwardedForAddr(r *http.Request) string {
+	xffValues := r.Header.Values("X-Forwarded-For")
+	if len(xffValues) == 0 {
+		return ""
+	}
+	// Split on commas defensively, in case a future tailscaled ever appends
+	// to an existing header instead of adding a new one.
+	segments := strings.Split(xffValues[len(xffValues)-1], ",")
+	for i := len(segments) - 1; i >= 0; i-- {
+		if addr := strings.TrimSpace(segments[i]); addr != "" {
+			return addr
+		}
+	}
+	return ""
+}
+
 // serveAuthorize handles the OAuth 2.0 authorization endpoint
 func (s *IDPServer) serveAuthorize(w http.ResponseWriter, r *http.Request) {
 	// This URL is visited by the user who is being authenticated. If they are
@@ -72,10 +91,7 @@ func (s *IDPServer) serveAuthorize(w http.ResponseWriter, r *http.Request) {
 	// Get user information
 	var remoteAddr string
 	if s.localTSMode {
-		xffValues := r.Header.Values("X-Forwarded-For")
-		if len(xffValues) > 0 {
-			remoteAddr = strings.TrimSpace(xffValues[len(xffValues)-1])
-		}
+		remoteAddr = lastForwardedForAddr(r)
 	} else {
 		remoteAddr = r.RemoteAddr
 	}

--- a/server/authorize_test.go
+++ b/server/authorize_test.go
@@ -733,3 +733,56 @@ func TestServeAuthorize(t *testing.T) {
 		})
 	}
 }
+
+func TestLastForwardedForAddr(t *testing.T) {
+	tests := []struct {
+		name string
+		xff  []string // one r.Header.Add call per entry, in order
+		want string
+	}{
+		{
+			name: "no header",
+			xff:  nil,
+			want: "",
+		},
+		{
+			name: "single header",
+			xff:  []string{"100.64.0.1"},
+			want: "100.64.0.1",
+		},
+		{
+			name: "single header with surrounding whitespace is trimmed",
+			xff:  []string{"  100.64.0.1  "},
+			want: "100.64.0.1",
+		},
+		{
+			name: "last header wins over client-supplied first header",
+			// a client could set its own header first, but tailscaled's own header is always last
+			xff:  []string{"100.64.0.99", "100.64.0.1"},
+			want: "100.64.0.1",
+		},
+		{
+			name: "comma-separated value in the last header uses the last segment",
+			xff:  []string{"100.64.0.0", "100.64.0.1, 100.64.0.2"},
+			want: "100.64.0.2",
+		},
+		{
+			name: "trailing comma falls back to the last non-empty segment",
+			xff:  []string{"100.64.0.1, 100.64.0.2,"},
+			want: "100.64.0.2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest("GET", "/", nil)
+			for _, v := range tt.xff {
+				r.Header.Add("X-Forwarded-For", v)
+			}
+
+			if got := lastForwardedForAddr(r); got != tt.want {
+				t.Errorf("lastForwardedForAddr() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/tsidp-server.go
+++ b/tsidp-server.go
@@ -89,15 +89,6 @@ func main() {
 		lns []net.Listener
 	)
 	if *flagUseLocalTailscaled {
-		fmt.Println("")
-		fmt.Println("┌─[ IMPORTANT WARNING ]────────────────────────────────────────────────────┐")
-		fmt.Println("│                                                                          │")
-		fmt.Println("│  -use-local-tailscaled is for development only.                          │")
-		fmt.Println("│                                                                          │")
-		fmt.Println("│  Do not use it in production deployments.                                │")
-		fmt.Println("│                                                                          │")
-		fmt.Println("└──────────────────────────────────────────────────────────────────────────┘")
-		fmt.Println("")
 		lc = &local.Client{}
 		st, err = lc.StatusWithoutPeers(ctx)
 		if err != nil {


### PR DESCRIPTION
When running against a local tailscaled (`-use-local-tailscaled`), tsidp identifies the calling user via the `X-Forwarded-For` header. It currently takes the first `X-Forwarded-For` value, but a client can set that header itself, letting it name an arbitrary peer and impersonate any user on the tailnet.

This changes tsidp to use the last `X-Forwarded-For` header instead: tailscaled always appends the real peer address as a new header rather than editing one the client already sent, so the last header is the one that can be trusted.