### PR TITLE
Support public oidc clients (who don't support secrets)

### DIFF
--- a/server/oauth-metadata.go
+++ b/server/oauth-metadata.go
@@ -73,7 +73,7 @@ var (
 
 	// OAuth 2.0 specific metadata constants
 	oauthSupportedGrantTypes               = views.SliceOf([]string{"authorization_code", "refresh_token"})
-	oauthSupportedTokenEndpointAuthMethods = views.SliceOf([]string{"client_secret_post", "client_secret_basic"})
+	oauthSupportedTokenEndpointAuthMethods = views.SliceOf([]string{"client_secret_post", "client_secret_basic", "none"})
 
 	// PKCE support (RFC 7636)
 	pkceCodeChallengeMethodsSupported = views.SliceOf([]string{"plain", "S256"})

--- a/server/token.go
+++ b/server/token.go
@@ -910,15 +910,29 @@ func (ar *AuthRequest) allowRelyingParty(r *http.Request) (int, error) {
 		clientSecret = r.FormValue("client_secret")
 	}
 
-	if clientID == "" || clientSecret == "" {
+	if clientID == "" {
 		return http.StatusUnauthorized, fmt.Errorf("tsidp: missing client credentials")
 	}
 
 	clientIDcmp := subtle.ConstantTimeCompare([]byte(clientID), []byte(ar.FunnelRP.ID))
-	clientSecretcmp := subtle.ConstantTimeCompare([]byte(clientSecret), []byte(ar.FunnelRP.Secret))
 	if clientIDcmp != 1 {
 		return http.StatusBadRequest, fmt.Errorf("tsidp: client_id mismatch")
 	}
+
+	// Public clients (RFC 6749 §2.1, OIDC Core §9) authenticate via PKCE
+	// instead of a client secret, so don't require one here. PKCE itself is
+	// enforced by the code_verifier check in handleAuthorizationCodeGrant.
+	if ar.FunnelRP.TokenEndpointAuthMethod == "none" {
+		if ar.CodeChallenge == "" {
+			return http.StatusUnauthorized, fmt.Errorf("tsidp: public client requires PKCE")
+		}
+		return http.StatusOK, nil
+	}
+
+	if clientSecret == "" {
+		return http.StatusUnauthorized, fmt.Errorf("tsidp: missing client credentials")
+	}
+	clientSecretcmp := subtle.ConstantTimeCompare([]byte(clientSecret), []byte(ar.FunnelRP.Secret))
 	if clientSecretcmp != 1 {
 		return http.StatusUnauthorized, fmt.Errorf("tsidp: invalid client secret: [%s] [%s]", clientID, clientSecret)
 	}

--- a/server/token_test.go
+++ b/server/token_test.go
@@ -1364,20 +1364,24 @@ func TestServeToken(t *testing.T) {
 // TestServeTokenWithClientValidation verifies OAuth token endpoint security
 func TestServeTokenWithClientValidation(t *testing.T) {
 	tests := []struct {
-		name                string
-		method              string
-		grantType           string
-		code                string
-		clientID            string
-		clientSecret        string
-		redirectURI         string
-		useBasicAuth        bool
-		setupAuthRequest    bool
-		authRequestClient   string
-		authRequestRedirect string
-		expectError         bool
-		expectCode          int
-		expectIDToken       bool
+		name                    string
+		method                  string
+		grantType               string
+		code                    string
+		clientID                string
+		clientSecret            string
+		redirectURI             string
+		useBasicAuth            bool
+		setupAuthRequest        bool
+		authRequestClient       string
+		authRequestRedirect     string
+		tokenEndpointAuthMethod string
+		codeChallenge           string
+		codeChallengeMethod     string
+		codeVerifier            string
+		expectError             bool
+		expectCode              int
+		expectIDToken           bool
 	}{
 		{
 			name:                "valid token exchange with form credentials",
@@ -1459,6 +1463,36 @@ func TestServeTokenWithClientValidation(t *testing.T) {
 			expectError:         true,
 			expectCode:          http.StatusBadRequest,
 		},
+		{
+			name:                    "public client with valid PKCE and no client_secret",
+			method:                  "POST",
+			grantType:               "authorization_code",
+			code:                    "valid-code",
+			clientID:                "test-client",
+			redirectURI:             "https://rp.example.com/callback",
+			setupAuthRequest:        true,
+			authRequestClient:       "test-client",
+			authRequestRedirect:     "https://rp.example.com/callback",
+			tokenEndpointAuthMethod: "none",
+			codeChallenge:           "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+			codeChallengeMethod:     "S256",
+			codeVerifier:            "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+			expectIDToken:           true,
+		},
+		{
+			name:                    "public client without PKCE is rejected",
+			method:                  "POST",
+			grantType:               "authorization_code",
+			code:                    "valid-code",
+			clientID:                "test-client",
+			redirectURI:             "https://rp.example.com/callback",
+			setupAuthRequest:        true,
+			authRequestClient:       "test-client",
+			authRequestRedirect:     "https://rp.example.com/callback",
+			tokenEndpointAuthMethod: "none",
+			expectError:             true,
+			expectCode:              http.StatusUnauthorized,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1490,21 +1524,24 @@ func TestServeTokenWithClientValidation(t *testing.T) {
 				var funnelClientPtr *FunnelClient
 				if tt.authRequestClient != "" {
 					funnelClientPtr = &FunnelClient{
-						ID:          tt.authRequestClient,
-						Secret:      "test-secret",
-						Name:        "Test Client",
-						RedirectURI: tt.authRequestRedirect,
+						ID:                      tt.authRequestClient,
+						Secret:                  "test-secret",
+						Name:                    "Test Client",
+						RedirectURI:             tt.authRequestRedirect,
+						TokenEndpointAuthMethod: tt.tokenEndpointAuthMethod,
 					}
 					srv.funnelClients[tt.authRequestClient] = funnelClientPtr
 				}
 
 				srv.code["valid-code"] = &AuthRequest{
-					ClientID:    tt.authRequestClient,
-					Nonce:       "nonce123",
-					RedirectURI: tt.authRequestRedirect,
-					ValidTill:   now.Add(5 * time.Minute),
-					RemoteUser:  remoteUser,
-					FunnelRP:    funnelClientPtr,
+					ClientID:            tt.authRequestClient,
+					Nonce:               "nonce123",
+					RedirectURI:         tt.authRequestRedirect,
+					ValidTill:           now.Add(5 * time.Minute),
+					RemoteUser:          remoteUser,
+					FunnelRP:            funnelClientPtr,
+					CodeChallenge:       tt.codeChallenge,
+					CodeChallengeMethod: tt.codeChallengeMethod,
 				}
 			}
 
@@ -1513,6 +1550,9 @@ func TestServeTokenWithClientValidation(t *testing.T) {
 			form.Set("grant_type", tt.grantType)
 			form.Set("code", tt.code)
 			form.Set("redirect_uri", tt.redirectURI)
+			if tt.codeVerifier != "" {
+				form.Set("code_verifier", tt.codeVerifier)
+			}
 
 			if !tt.useBasicAuth {
 				if tt.clientID != "" {

--- a/server/ui-edit.html
+++ b/server/ui-edit.html
@@ -22,10 +22,9 @@
         </div>
         {{end}}
 
-        {{if and .Secret .IsNew}}
+        {{if and .ID .IsNew}}
         <div class="client-info">
             <h3>Client Created Successfully!</h3>
-            <p class="warning">⚠️ Save both the Client ID and Secret now! The secret will not be shown again.</p>
 
             <div class="form-group">
                 <label>Client ID</label>
@@ -35,6 +34,8 @@
                 </div>
             </div>
 
+            {{if .Secret}}
+            <p class="warning">⚠️ Save both the Client ID and Secret now! The secret will not be shown again.</p>
             <div class="form-group">
                 <label>Client Secret</label>
                 <div class="secret-field">
@@ -42,6 +43,9 @@
                     <button type="button" onclick="copyValue(this.previousElementSibling, this)" class="btn btn-secondary btn-small">Copy</button>
                 </div>
             </div>
+            {{else}}
+            <p>This is a public client — no secret was issued. It authenticates using PKCE only.</p>
+            {{end}}
         </div>
         {{end}}
 
@@ -72,6 +76,25 @@
                 </div>
             </div>
 
+            {{if .IsNew}}
+            <div class="form-group">
+                <label for="token_endpoint_auth_method">Client authentication method</label>
+                <select
+                        id="token_endpoint_auth_method"
+                        name="token_endpoint_auth_method"
+                        class="form-input"
+                >
+                    <option value="client_secret_basic" {{if ne .TokenEndpointAuthMethod "none"}}selected{{end}}>Confidential (client secret)</option>
+                    <option value="none" {{if eq .TokenEndpointAuthMethod "none"}}selected{{end}}>Public (no secret, PKCE required)</option>
+                </select>
+                <div class="form-help">
+                    Public clients don't get a secret. PKCE is required (not optional)
+                    for public clients — the relying party must send a code_challenge
+                    at authorization time, or token exchange will be rejected.
+                </div>
+            </div>
+            {{end}}
+
             <div class="form-group">
                 <label for="redirect_uris">Redirect URIs <span class="required">*</span></label>
                 <textarea
@@ -100,6 +123,19 @@
                     The client ID cannot be changed.
                 </div>
             </div>
+
+            <div class="form-group">
+                <label>Client Authentication Method</label>
+                <input
+                        type="text"
+                        value="{{if .IsPublic}}Public (no secret, PKCE){{else}}Confidential (client secret){{end}}"
+                        readonly
+                        class="form-input form-input-readonly"
+                >
+                <div class="form-help">
+                    The authentication method is set at creation and cannot be changed. Delete and recreate the client to switch.
+                </div>
+            </div>
             {{end}}
 
             <div class="form-actions">
@@ -108,10 +144,12 @@
                 </button>
 
                 {{if .IsEdit}}
+                {{if not .IsPublic}}
                 <button type="submit" name="action" value="regenerate_secret" class="btn btn-warning"
                         onclick="return confirm('Are you sure you want to regenerate the client secret? The old secret will stop working immediately.')">
                     Regenerate Secret
                 </button>
+                {{end}}
 
                 <button type="submit" name="action" value="delete" class="btn btn-danger"
                         onclick="return confirm('Are you sure you want to delete this client? This cannot be undone.')">
@@ -129,7 +167,9 @@
                 <dd><code>{{.ID}}</code></dd>
                 <dt>Secret Status</dt>
                 <dd>
-                    {{if .HasSecret}}
+                    {{if .IsPublic}}
+                    <span class="status-inactive">Public (no secret)</span>
+                    {{else if .HasSecret}}
                     <span class="status-active">Secret configured</span>
                     {{else}}
                     <span class="status-inactive">No secret</span>

--- a/server/ui-list.html
+++ b/server/ui-list.html
@@ -48,7 +48,9 @@
                 {{end}}
             </td>
             <td>
-                {{if .HasSecret}}
+                {{if .IsPublic}}
+                <span class="status-inactive">Public</span>
+                {{else if .HasSecret}}
                 <span class="status-active">Active</span>
                 {{else}}
                 <span class="status-inactive">No Secret</span>

--- a/server/ui.go
+++ b/server/ui.go
@@ -112,10 +112,12 @@ func (s *IDPServer) handleClientsList(w http.ResponseWriter, r *http.Request) {
 	clients := make([]clientDisplayData, 0, len(s.funnelClients))
 	for _, c := range s.funnelClients {
 		clients = append(clients, clientDisplayData{
-			ID:           c.ID,
-			Name:         c.Name,
-			RedirectURIs: c.RedirectURIs,
-			HasSecret:    c.Secret != "",
+			ID:                      c.ID,
+			Name:                    c.Name,
+			RedirectURIs:            c.RedirectURIs,
+			HasSecret:               c.Secret != "",
+			TokenEndpointAuthMethod: c.TokenEndpointAuthMethod,
+			IsPublic:                c.TokenEndpointAuthMethod == "none",
 		})
 	}
 	s.mu.Unlock()
@@ -161,11 +163,13 @@ func (s *IDPServer) handleNewClient(w http.ResponseWriter, r *http.Request) {
 		name := strings.TrimSpace(r.FormValue("name"))
 		redirectURIsText := strings.TrimSpace(r.FormValue("redirect_uris"))
 		redirectURIs := splitRedirectURIs(redirectURIsText)
+		authMethodInput := r.FormValue("token_endpoint_auth_method")
 
 		baseData := clientDisplayData{
-			IsNew:        true,
-			Name:         name,
-			RedirectURIs: redirectURIs,
+			IsNew:                   true,
+			Name:                    name,
+			RedirectURIs:            redirectURIs,
+			TokenEndpointAuthMethod: authMethodInput,
 		}
 
 		if len(redirectURIs) == 0 {
@@ -180,13 +184,24 @@ func (s *IDPServer) handleNewClient(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
+		// Anything other than "none" is treated as confidential, matching
+		// how DCR defaults a missing/unrecognized value (clients.go:341-343).
+		authMethod := authMethodInput
+		if authMethod != "none" {
+			authMethod = "client_secret_basic"
+		}
+
 		clientID := rands.HexString(32)
-		clientSecret := rands.HexString(64)
+		var clientSecret string
+		if authMethod != "none" {
+			clientSecret = rands.HexString(64)
+		}
 		newClient := FunnelClient{
-			ID:           clientID,
-			Secret:       clientSecret,
-			Name:         name,
-			RedirectURIs: redirectURIs,
+			ID:                      clientID,
+			Secret:                  clientSecret,
+			Name:                    name,
+			RedirectURIs:            redirectURIs,
+			TokenEndpointAuthMethod: authMethod,
 		}
 
 		s.mu.Lock()
@@ -203,14 +218,21 @@ func (s *IDPServer) handleNewClient(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		successData := clientDisplayData{
-			ID:           clientID,
-			Name:         name,
-			RedirectURIs: redirectURIs,
-			Secret:       clientSecret,
-			IsNew:        true,
+		successMsg := "Client created successfully! Save the client secret - it won't be shown again."
+		if authMethod == "none" {
+			successMsg = "Public client created successfully!"
 		}
-		s.renderFormSuccess(w, r, successData, "Client created successfully! Save the client secret - it won't be shown again.")
+
+		successData := clientDisplayData{
+			ID:                      clientID,
+			Name:                    name,
+			RedirectURIs:            redirectURIs,
+			Secret:                  clientSecret,
+			TokenEndpointAuthMethod: authMethod,
+			IsPublic:                authMethod == "none",
+			IsNew:                   true,
+		}
+		s.renderFormSuccess(w, r, successData, successMsg)
 		return
 	}
 
@@ -237,11 +259,13 @@ func (s *IDPServer) handleEditClient(w http.ResponseWriter, r *http.Request) {
 
 	if r.Method == "GET" {
 		data := clientDisplayData{
-			ID:           client.ID,
-			Name:         client.Name,
-			RedirectURIs: client.RedirectURIs,
-			HasSecret:    client.Secret != "",
-			IsEdit:       true,
+			ID:                      client.ID,
+			Name:                    client.Name,
+			RedirectURIs:            client.RedirectURIs,
+			HasSecret:               client.Secret != "",
+			TokenEndpointAuthMethod: client.TokenEndpointAuthMethod,
+			IsPublic:                client.TokenEndpointAuthMethod == "none",
+			IsEdit:                  true,
 		}
 		if err := s.renderClientForm(w, data); err != nil {
 			writeHTTPError(w, r, http.StatusInternalServerError, ecServerError, "failed to render form", err)
@@ -265,11 +289,13 @@ func (s *IDPServer) handleEditClient(w http.ResponseWriter, r *http.Request) {
 				s.mu.Unlock()
 
 				baseData := clientDisplayData{
-					ID:           client.ID,
-					Name:         client.Name,
-					RedirectURIs: client.RedirectURIs,
-					HasSecret:    client.Secret != "",
-					IsEdit:       true,
+					ID:                      client.ID,
+					Name:                    client.Name,
+					RedirectURIs:            client.RedirectURIs,
+					HasSecret:               client.Secret != "",
+					TokenEndpointAuthMethod: client.TokenEndpointAuthMethod,
+					IsPublic:                client.TokenEndpointAuthMethod == "none",
+					IsEdit:                  true,
 				}
 				s.renderFormError(w, r, baseData, "Failed to delete client. Please try again.")
 				return
@@ -280,19 +306,28 @@ func (s *IDPServer) handleEditClient(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if action == "regenerate_secret" {
+			baseData := clientDisplayData{
+				ID:                      client.ID,
+				Name:                    client.Name,
+				RedirectURIs:            client.RedirectURIs,
+				HasSecret:               client.Secret != "",
+				TokenEndpointAuthMethod: client.TokenEndpointAuthMethod,
+				IsPublic:                client.TokenEndpointAuthMethod == "none",
+				IsEdit:                  true,
+			}
+
+			if client.TokenEndpointAuthMethod == "none" {
+				s.renderFormError(w, r, baseData, "Public clients don't have a secret to regenerate.")
+				return
+			}
+
 			newSecret := rands.HexString(64)
 			s.mu.Lock()
 			s.funnelClients[clientID].Secret = newSecret
 			err := s.storeFunnelClientsLocked()
 			s.mu.Unlock()
 
-			baseData := clientDisplayData{
-				ID:           client.ID,
-				Name:         client.Name,
-				RedirectURIs: client.RedirectURIs,
-				HasSecret:    true,
-				IsEdit:       true,
-			}
+			baseData.HasSecret = true
 
 			if err != nil {
 				slog.Error("client regen secret: could not write funnel clients db", slog.Any("error", err))
@@ -314,11 +349,13 @@ func (s *IDPServer) handleEditClient(w http.ResponseWriter, r *http.Request) {
 		redirectURIsText := strings.TrimSpace(r.FormValue("redirect_uris"))
 		redirectURIs := splitRedirectURIs(redirectURIsText)
 		baseData := clientDisplayData{
-			ID:           client.ID,
-			Name:         name,
-			RedirectURIs: redirectURIs,
-			HasSecret:    client.Secret != "",
-			IsEdit:       true,
+			ID:                      client.ID,
+			Name:                    name,
+			RedirectURIs:            redirectURIs,
+			HasSecret:               client.Secret != "",
+			TokenEndpointAuthMethod: client.TokenEndpointAuthMethod,
+			IsPublic:                client.TokenEndpointAuthMethod == "none",
+			IsEdit:                  true,
 		}
 
 		if len(redirectURIs) == 0 {
@@ -355,15 +392,17 @@ func (s *IDPServer) handleEditClient(w http.ResponseWriter, r *http.Request) {
 // clientDisplayData holds data for rendering client forms
 // Migrated from legacy/ui.go:321-331
 type clientDisplayData struct {
-	ID           string
-	Name         string
-	RedirectURIs []string
-	Secret       string
-	HasSecret    bool
-	IsNew        bool
-	IsEdit       bool
-	Success      string
-	Error        string
+	ID                      string
+	Name                    string
+	RedirectURIs            []string
+	Secret                  string
+	HasSecret               bool
+	TokenEndpointAuthMethod string
+	IsPublic                bool
+	IsNew                   bool
+	IsEdit                  bool
+	Success                 string
+	Error                   string
 }
 
 // listPageData holds data for rendering the clients list page

--- a/server/ui_test.go
+++ b/server/ui_test.go
@@ -6,6 +6,8 @@ package server
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 )
 
@@ -106,6 +108,149 @@ func TestValidateRedirectURI(t *testing.T) {
 				t.Errorf("validateRedirectURI(%q) = %q, want %q", tt.uri, got, tt.want)
 			}
 		})
+	}
+}
+
+func newClientForm(t *testing.T, values url.Values) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/new", strings.NewReader(values.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	return req
+}
+
+func TestHandleNewClientPublic(t *testing.T) {
+	s := &IDPServer{
+		funnelClients: make(map[string]*FunnelClient),
+		stateDir:      t.TempDir(),
+	}
+
+	form := url.Values{
+		"name":                       {"Incus"},
+		"redirect_uris":              {"https://host.example.ts.net/oidc/callback"},
+		"token_endpoint_auth_method": {"none"},
+	}
+
+	rr := httptest.NewRecorder()
+	s.handleNewClient(rr, newClientForm(t, form))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	if strings.Contains(rr.Body.String(), "Client Secret") {
+		t.Error("expected no Client Secret field in response for a public client")
+	}
+	if !strings.Contains(rr.Body.String(), "public client") {
+		t.Error("expected response to explain this is a public client")
+	}
+
+	if len(s.funnelClients) != 1 {
+		t.Fatalf("expected exactly one stored client, got %d", len(s.funnelClients))
+	}
+	for _, c := range s.funnelClients {
+		if c.Secret != "" {
+			t.Errorf("expected empty secret for public client, got %q", c.Secret)
+		}
+		if c.TokenEndpointAuthMethod != "none" {
+			t.Errorf("expected TokenEndpointAuthMethod %q, got %q", "none", c.TokenEndpointAuthMethod)
+		}
+	}
+}
+
+func TestHandleNewClientConfidentialDefault(t *testing.T) {
+	s := &IDPServer{
+		funnelClients: make(map[string]*FunnelClient),
+		stateDir:      t.TempDir(),
+	}
+
+	form := url.Values{
+		"name":          {"My App"},
+		"redirect_uris": {"https://example.com/callback"},
+		// token_endpoint_auth_method intentionally omitted
+	}
+
+	rr := httptest.NewRecorder()
+	s.handleNewClient(rr, newClientForm(t, form))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	if !strings.Contains(rr.Body.String(), "Client Secret") {
+		t.Error("expected a Client Secret field in response for a confidential client")
+	}
+
+	if len(s.funnelClients) != 1 {
+		t.Fatalf("expected exactly one stored client, got %d", len(s.funnelClients))
+	}
+	for _, c := range s.funnelClients {
+		if c.Secret == "" {
+			t.Error("expected a non-empty secret for confidential client")
+		}
+		if c.TokenEndpointAuthMethod != "client_secret_basic" {
+			t.Errorf("expected TokenEndpointAuthMethod %q, got %q", "client_secret_basic", c.TokenEndpointAuthMethod)
+		}
+	}
+}
+
+func TestHandleEditClientPublicHidesRegenerate(t *testing.T) {
+	s := &IDPServer{
+		funnelClients: map[string]*FunnelClient{
+			"public-client": {
+				ID:                      "public-client",
+				Name:                    "Incus",
+				RedirectURIs:            []string{"https://host.example.ts.net/oidc/callback"},
+				TokenEndpointAuthMethod: "none",
+			},
+		},
+		stateDir: t.TempDir(),
+	}
+
+	req := httptest.NewRequest("GET", "/edit/public-client", nil)
+	rr := httptest.NewRecorder()
+	s.handleEditClient(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	body := rr.Body.String()
+	if strings.Contains(body, "Regenerate Secret") {
+		t.Error("expected no Regenerate Secret button for a public client")
+	}
+	if !strings.Contains(body, "Public (no secret, PKCE)") {
+		t.Error("expected the read-only auth method to say Public")
+	}
+}
+
+func TestHandleEditClientRegenerateSecretRejectedForPublicClient(t *testing.T) {
+	s := &IDPServer{
+		funnelClients: map[string]*FunnelClient{
+			"public-client": {
+				ID:                      "public-client",
+				Name:                    "Incus",
+				RedirectURIs:            []string{"https://host.example.ts.net/oidc/callback"},
+				TokenEndpointAuthMethod: "none",
+			},
+		},
+		stateDir: t.TempDir(),
+	}
+
+	form := url.Values{"action": {"regenerate_secret"}}
+	req := httptest.NewRequest("POST", "/edit/public-client", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	rr := httptest.NewRecorder()
+	s.handleEditClient(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "have a secret to regenerate") {
+		t.Error("expected an error explaining public clients have no secret to regenerate")
+	}
+	if s.funnelClients["public-client"].Secret != "" {
+		t.Error("expected secret to remain empty after rejected regenerate attempt")
 	}
 }
 


### PR DESCRIPTION
This PR closes #174 

I am trying to use tsidp for `incus`, but this project only supports public OIDC clients, i.e., without secrets. This PR adds support to create such clients, by updating the front end to allow registration of public clients, and the back-end to enforce PKCE validation for public clients while not requiring client secrets in that case.

**AI usage:** Claude did help with this change, but I carefully reviewed and tested it.

Issuing tokens to Incus is working with this PR, but Incus also expects the token to be offline-verifiable (i.e., be a valid JWT), which is a separate piece of work.

## UI changes:

<img width="617" height="627" alt="image" src="https://github.com/user-attachments/assets/868196b5-a44d-4ed0-a03f-46abc9896585" />

<img width="625" height="902" alt="image" src="https://github.com/user-attachments/assets/0749130f-c7b8-450e-838f-ed7eb56f9916" />




 