### PR TITLE
Support workload identity federation for node registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,26 @@ Once tsidp has started, visit `https://idp.yourtailnet.ts.net` in a browser to c
 >   - TS_ADVERTISE_TAGS=tag:tsidp
 > ```
 
+> [!NOTE]
+> **Using Workload Identity Federation**
+>
+> On platforms that can issue OIDC ID tokens for workloads (AWS, Google Cloud, GitHub Actions, or any custom issuer), tsidp can register itself without any stored secret using [workload identity federation](https://tailscale.com/docs/features/workload-identity-federation).
+>
+> **Setup:**
+> 1. In the [Tailscale admin console](https://login.tailscale.com/admin/settings/trust-credentials), create a federated trust credential with **Auth Keys → Write** scope
+> 2. Ensure the advertise tag (e.g. `tag:tsidp`) is defined in your ACL `tagOwners`
+> 3. Set `TS_CLIENT_ID` to the trust credential's client ID, and either `TS_AUDIENCE` (automatic ID token discovery on supported platforms) or `TS_ID_TOKEN` (an ID token you obtained yourself)
+> 4. Set `TS_ADVERTISE_TAGS` (or `--advertise-tags`) — **required** when using workload identity federation
+>
+> Nodes registered this way are ephemeral by default; append `?ephemeral=false` to `TS_CLIENT_ID` so the tsidp node persists.
+>
+> ```yaml
+> environment:
+>   - TS_CLIENT_ID=tsclient-xxxxx?ephemeral=false
+>   - TS_AUDIENCE=my-configured-audience
+>   - TS_ADVERTISE_TAGS=tag:tsidp
+> ```
+
 ### Other Ways to Build and Run
 
 <details>
@@ -184,7 +204,10 @@ These environment variables are used when tsidp does not have any state informat
 > **Serverless/Stateless Deployment**: tsidp requires persistent state storage to function properly in production. Without a persistent `-dir`, the service will re-register with Tailscale on every restart, lose dynamic OIDC client registrations, and invalidate user sessions. Serverless environments without persistent storage are not recommended for production use.
 
 - `TS_AUTHKEY=<key>`: Key for registering a tsidp as a new node on your tailnet. Can be a traditional auth key or OAuth client secret (tskey-client-xxx). If omitted, a link will be printed to manually register.
-- `TS_ADVERTISE_TAGS=<tags>`: Comma-separated advertise tags (e.g., "tag:tsidp,tag:server"). Optional, but required when using OAuth client secrets.
+- `TS_ADVERTISE_TAGS=<tags>`: Comma-separated advertise tags (e.g., "tag:tsidp,tag:server"). Optional, but required when using OAuth client secrets or workload identity federation.
+- `TS_CLIENT_ID=<id>`: Client ID of a federated trust credential, used to register the node via [workload identity federation](https://tailscale.com/docs/features/workload-identity-federation) instead of `TS_AUTHKEY`. Use together with exactly one of `TS_ID_TOKEN` or `TS_AUDIENCE`. Nodes are ephemeral by default; append `?ephemeral=false` to keep the node registered.
+- `TS_ID_TOKEN=<jwt>`: OIDC ID token to exchange for an auth key when using workload identity federation.
+- `TS_AUDIENCE=<audience>`: Audience for automatic ID token discovery (AWS, Google Cloud, or GitHub Actions) when using workload identity federation.
 - `TSNET_FORCE_LOGIN=1`: Force re-login of the node. Useful during development.
 
 ### Docker Environment Variables

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,19 @@ require (
 	filippo.io/edwards25519 v1.2.0 // indirect
 	github.com/akutz/memconn v0.1.0 // indirect
 	github.com/alexbrainman/sspi v0.0.0-20231016080023-1a75b4708caa // indirect
+	github.com/aws/aws-sdk-go-v2 v1.41.0 // indirect
+	github.com/aws/aws-sdk-go-v2/config v1.29.5 // indirect
+	github.com/aws/aws-sdk-go-v2/credentials v1.17.58 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.27 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.16 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.16 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.2 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.4 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.16 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sso v1.24.14 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.28.13 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sts v1.41.5 // indirect
+	github.com/aws/smithy-go v1.24.0 // indirect
 	github.com/coder/websocket v1.8.12 // indirect
 	github.com/creachadair/msync v0.7.1 // indirect
 	github.com/dblohm7/wingoes v0.0.0-20240119213807-a09d6be7affa // indirect

--- a/tsidp-server.go
+++ b/tsidp-server.go
@@ -33,6 +33,10 @@ import (
 
 	"tailscale.com/tsnet"
 	"tailscale.com/version"
+
+	// Enable workload identity federation as an alternative to TS_AUTHKEY for
+	// registering the tsnet node (TS_CLIENT_ID plus TS_ID_TOKEN or TS_AUDIENCE).
+	_ "tailscale.com/feature/identityfederation"
 )
 
 // Command line flags


### PR DESCRIPTION
Fixes #116

tsnet has supported [workload identity federation](https://tailscale.com/docs/features/workload-identity-federation) for node registration since it went GA (`TS_CLIENT_ID` plus `TS_ID_TOKEN` or `TS_AUDIENCE`, resolved in `tsnet.Server.getAuthKey`), but the feature is opt-in at build time: the `tailscale.com/feature/identityfederation` hooks are only registered if the package is linked in. tsidp doesn't link it, so today the only way to auto-register a tsidp node is a stored `TS_AUTHKEY` (auth key or OAuth client secret) — exactly the kind of long-lived credential WIF exists to eliminate.

This PR:

- Adds a blank import of `tailscale.com/feature/identityfederation` to `tsidp-server.go`, enabling registration via `TS_CLIENT_ID` + `TS_ID_TOKEN`/`TS_AUDIENCE` with no code changes needed in tsidp itself (tsnet reads the env vars and mints a one-shot auth key via the token exchange).
- `go mod tidy` fallout: the feature pulls in the `wif` provider-token discovery, which adds the AWS SDK as indirect deps (used for automatic token discovery on AWS). `go.sum` is unchanged.
- Documents the new environment variables in the README (CLI env var reference + a quickstart note beside the existing OAuth-client-secret one), including that WIF-registered nodes default to ephemeral and tsidp deployments will typically want `TS_CLIENT_ID=...?ephemeral=false` since tsidp needs persistent state.

Verified: `go build`, `go vet`, and `go test ./...` pass; the built binary contains the WIF token-exchange path (hooks registered via the blank import's `init`).

One thing I could not regenerate: `flake.nix` pins `vendorHash` from `go.mod.sri`, and I don't have nix available — since the module graph grew, that hash likely needs a refresh. Happy to update if a maintainer can share the expected value, or feel free to push it onto the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)