### PR TITLE
fix(build): inject version via ldflags, fixes docker image showing "dev"

### DIFF
--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -52,6 +52,7 @@ jobs:
           # For PRs to this file tag the container "pull_request_test"
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "tags=ghcr.io/tailscale/tsidp:pull_request_test" >> $GITHUB_OUTPUT
+            echo "version=dev" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -59,11 +60,13 @@ jobs:
           if [ "${{ github.event_name }}" = "push" ]; then
             TAG="${REF#refs/tags/}"
             echo "tags=ghcr.io/tailscale/tsidp:${TAG},ghcr.io/tailscale/tsidp:latest" >> $GITHUB_OUTPUT
+            echo "version=${TAG#v}" >> $GITHUB_OUTPUT
             exit 0
           fi
 
           # For workflow_dispatch: use the provided tag
           echo "tags=ghcr.io/tailscale/tsidp:${TAG}" >> $GITHUB_OUTPUT
+          echo "version=${TAG#v}" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # 3.11.1
@@ -77,3 +80,5 @@ jobs:
           push: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push) }}
           tags: ${{ steps.image_tags.outputs.tags }}
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            VERSION=${{ steps.image_tags.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ WORKDIR /app
 # BuildKit will set these automatically when using buildx
 ARG TARGETOS
 ARG TARGETARCH
+ARG VERSION=dev
 
 # Copy go mod files from root
 COPY go.mod go.sum ./
@@ -22,7 +23,7 @@ COPY . ./
 
 # Build the binary for the target platform
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
-    go build -a -installsuffix cgo -o tsidp-server .
+    go build -a -installsuffix cgo -ldflags "-s -w -X github.com/tailscale/tsidp/server.version=${VERSION}" -o tsidp-server .
 
 # Final stage
 FROM alpine:3.22


### PR DESCRIPTION
Docker images built by `containers.yaml` show `version=dev` instead of the tag (e.g. found on `v0.0.15`).

The container build step ran plain `go build` with no ldflags, unlike the goreleaser release build which injects `server.version` via `-X`.

---

Changes made:
  - Add `VERSION` build-arg to `Dockerfile`, pass through via ldflags into `server.version`
  - `containers.yaml` now derives `VERSION` (tag with `v` stripped, matching goreleaser's `.Version` convention) and passes it as `--build-arg`
