### PR TITLE
feat: support auth key from file (TS_AUTHKEY_FILE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ These environment variables are used when tsidp does not have any state informat
 > **Serverless/Stateless Deployment**: tsidp requires persistent state storage to function properly in production. Without a persistent `-dir`, the service will re-register with Tailscale on every restart, lose dynamic OIDC client registrations, and invalidate user sessions. Serverless environments without persistent storage are not recommended for production use.
 
 - `TS_AUTHKEY=<key>`: Key for registering a tsidp as a new node on your tailnet. Can be a traditional auth key or OAuth client secret (tskey-client-xxx). If omitted, a link will be printed to manually register.
-- `TS_AUTHKEY_FILE=<path>` / `-authkey-file <path>`: Path to a file containing the auth key, for setups that mount the key as a file instead of an env var (e.g. Docker/Kubernetes secrets). If `TS_AUTHKEY` (or legacy `TS_AUTH_KEY`) is also set, that env var wins and the file is ignored (with a warning logged). Has no effect with `-use-local-tailscaled`, since that mode reuses an already-registered node.
+- `TS_AUTHKEY_FILE=<path>` / `-authkey-file <path>`: Same as `TS_AUTHKEY`, but reads the key from a file - useful when your key comes from a Docker/Kubernetes secret instead of an env var. Don't set this alongside `TS_AUTHKEY`; tsidp will refuse to start rather than guess which one you meant. If the file is missing, tsidp just logs a warning and carries on (it may already be registered from a previous boot). No effect with `-use-local-tailscaled`.
 - `TS_ADVERTISE_TAGS=<tags>`: Comma-separated advertise tags (e.g., "tag:tsidp,tag:server"). Optional, but required when using OAuth client secrets.
 - `TSNET_FORCE_LOGIN=1`: Force re-login of the node. Useful during development.
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,30 @@ Once tsidp has started, visit `https://idp.yourtailnet.ts.net` in a browser to c
 >   - TS_ADVERTISE_TAGS=tag:tsidp
 > ```
 
+> [!NOTE]
+> **Using Docker Secrets**
+>
+> Passing `TS_AUTHKEY` as a plain environment variable puts the key in `docker inspect` output and the container's process environment. To avoid that, mount the key as a [Docker secret](https://docs.docker.com/compose/how-tos/use-secrets/) and point tsidp at the mounted file with `TS_AUTHKEY_FILE` instead:
+>
+> ```yaml
+> services:
+>   tsidp:
+>     image: ghcr.io/tailscale/tsidp:latest
+>     environment:
+>       - TAILSCALE_USE_WIP_CODE=1
+>       - TS_STATE_DIR=/data
+>       - TS_AUTHKEY_FILE=/run/secrets/ts_authkey
+>     volumes:
+>       - tsidp-data:/data
+>     secrets:
+>       - ts_authkey
+> secrets:
+>   ts_authkey:
+>     file: ./ts_authkey.txt
+> volumes:
+>   tsidp-data:
+> ```
+
 ### Other Ways to Build and Run
 
 <details>
@@ -184,6 +208,7 @@ These environment variables are used when tsidp does not have any state informat
 > **Serverless/Stateless Deployment**: tsidp requires persistent state storage to function properly in production. Without a persistent `-dir`, the service will re-register with Tailscale on every restart, lose dynamic OIDC client registrations, and invalidate user sessions. Serverless environments without persistent storage are not recommended for production use.
 
 - `TS_AUTHKEY=<key>`: Key for registering a tsidp as a new node on your tailnet. Can be a traditional auth key or OAuth client secret (tskey-client-xxx). If omitted, a link will be printed to manually register.
+- `TS_AUTHKEY_FILE=<path>` / `-authkey-file <path>`: Path to a file containing the auth key, for setups that mount the key as a file instead of an env var (e.g. Docker/Kubernetes secrets). If `TS_AUTHKEY` (or legacy `TS_AUTH_KEY`) is also set, that env var wins and the file is ignored (with a warning logged). Has no effect with `-use-local-tailscaled`, since that mode reuses an already-registered node.
 - `TS_ADVERTISE_TAGS=<tags>`: Comma-separated advertise tags (e.g., "tag:tsidp,tag:server"). Optional, but required when using OAuth client secrets.
 - `TSNET_FORCE_LOGIN=1`: Force re-login of the node. Useful during development.
 
@@ -200,12 +225,14 @@ The Docker image exposes the CLI flags through environment variables. If omitted
 | `TS_HOSTNAME=<hostname>` _\*note prefix_ | `-hostname <hostname>`     |
 | `TSIDP_PORT=<port>`                      | `-port <port>`             |
 | `TSIDP_LOCAL_PORT=<local-port>`          | `-local-port <local-port>` |
+| `TSIDP_USE_LOCAL_TAILSCALED=1`           | `-use-local-tailscaled`    |
 | `TSIDP_USE_FUNNEL=1`                     | `-funnel`                  |
 | `TSIDP_ENABLE_STS=1`                     | `-enable-sts`              |
 | `TSIDP_LOG=<level>`                      | `-log <level>`             |
 | `TSIDP_DEBUG_TSNET=1`                    | `-debug-tsnet`             |
 | `TSIDP_DEBUG_ALL_REQUESTS=1`             | `-debug-all-requests`      |
 | `TS_AUTHKEY=<key>`                       | _(env var only)_           |
+| `TS_AUTHKEY_FILE=<path>`                 | `-authkey-file <path>`     |
 | `TS_ADVERTISE_TAGS=<tags>`               | `-advertise-tags <tags>`   |
 
 ## Application Configuration Guides (WIP)

--- a/tsidp-server.go
+++ b/tsidp-server.go
@@ -148,17 +148,19 @@ func main() {
 		}
 
 		if *flagAuthKeyFile != "" {
-			explicitKeySet := cmp.Or(envknob.String("TS_AUTHKEY"), envknob.String("TS_AUTH_KEY")) != ""
-			res := resolveAuthKeyFile(*flagAuthKeyFile, explicitKeySet)
-			if res.fatal != "" {
-				slog.Error(res.fatal, slog.String("path", *flagAuthKeyFile))
+			if cmp.Or(envknob.String("TS_AUTHKEY"), envknob.String("TS_AUTH_KEY")) != "" {
+				slog.Error("-authkey-file and TS_AUTHKEY/TS_AUTH_KEY are mutually exclusive; unset one", slog.String("path", *flagAuthKeyFile))
 				os.Exit(1)
 			}
-			if res.warn != "" {
-				slog.Warn(res.warn, slog.String("path", *flagAuthKeyFile))
+			key, err := resolveAuthKeyFile(*flagAuthKeyFile)
+			if err != nil {
+				slog.Error("could not read authkey file", slog.String("path", *flagAuthKeyFile), slog.Any("error", err))
+				os.Exit(1)
 			}
-			if res.key != "" {
-				ts.AuthKey = res.key
+			if key == "" {
+				slog.Warn("authkey file not found, continuing without it (node may already be registered)", slog.String("path", *flagAuthKeyFile))
+			} else {
+				ts.AuthKey = key
 				slog.Info("using auth key from file", slog.String("path", *flagAuthKeyFile))
 			}
 		}
@@ -410,27 +412,12 @@ func readAuthKeyFile(path string) (string, error) {
 	return key, nil
 }
 
-// authKeyFileResult is the outcome of resolveAuthKeyFile: at most one of
-// fatal, warn, or key is set.
-type authKeyFileResult struct {
-	key   string // resolved auth key, if any
-	warn  string // non-fatal message to log and continue
-	fatal string // message to log before exiting
-}
-
-// resolveAuthKeyFile decides what to do with -authkey-file given whether
-// TS_AUTHKEY/TS_AUTH_KEY is also set explicitly.
-func resolveAuthKeyFile(path string, explicitKeySet bool) authKeyFileResult {
-	if explicitKeySet {
-		return authKeyFileResult{fatal: "-authkey-file and TS_AUTHKEY/TS_AUTH_KEY are mutually exclusive; unset one"}
+// resolveAuthKeyFile is like readAuthKeyFile, but treats a missing file as
+// ("", nil) instead of an error, since the node may already be registered.
+func resolveAuthKeyFile(path string) (key string, err error) {
+	key, err = readAuthKeyFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", nil
 	}
-	key, err := readAuthKeyFile(path)
-	switch {
-	case errors.Is(err, os.ErrNotExist):
-		return authKeyFileResult{warn: "authkey file not found, continuing without it (node may already be registered)"}
-	case err != nil:
-		return authKeyFileResult{fatal: fmt.Sprintf("could not read authkey file: %v", err)}
-	default:
-		return authKeyFileResult{key: key}
-	}
+	return key, err
 }

--- a/tsidp-server.go
+++ b/tsidp-server.go
@@ -45,6 +45,7 @@ var (
 	flagDir                = flag.String("dir", envknob.String("TS_STATE_DIR"), "tsnet state directory; a default one will be created if not provided")
 	flagEnableSTS          = flag.Bool("enable-sts", envknob.Bool("TSIDP_ENABLE_STS"), "enable OIDC STS token exchange support")
 	flagAdvertiseTags      = flag.String("advertise-tags", envknob.String("TS_ADVERTISE_TAGS"), "comma-separated advertise tags (e.g. tag:tsidp,tag:server); required when using OAuth client secrets")
+	flagAuthKeyFile        = flag.String("authkey-file", envknob.String("TS_AUTHKEY_FILE"), "path to a file containing the Tailscale auth key (e.g. a Docker/Kubernetes secret); TS_AUTHKEY takes precedence if also set")
 
 	// application logging levels
 	flagLogLevel = flag.String("log", cmp.Or(envknob.String("TSIDP_LOG"), "info"), "log levels: debug, info, warn, error")
@@ -89,6 +90,9 @@ func main() {
 		lns []net.Listener
 	)
 	if *flagUseLocalTailscaled {
+		if *flagAuthKeyFile != "" {
+			slog.Warn("authkey-file has no effect with -use-local-tailscaled", slog.String("path", *flagAuthKeyFile))
+		}
 		fmt.Println("")
 		fmt.Println("┌─[ IMPORTANT WARNING ]────────────────────────────────────────────────────┐")
 		fmt.Println("│                                                                          │")
@@ -141,6 +145,20 @@ func main() {
 		ts := &tsnet.Server{
 			Hostname: *flagHostname,
 			Dir:      *flagDir,
+		}
+
+		if *flagAuthKeyFile != "" {
+			if v := cmp.Or(envknob.String("TS_AUTHKEY"), envknob.String("TS_AUTH_KEY")); v != "" {
+				slog.Warn("authkey-file ignored: TS_AUTHKEY/TS_AUTH_KEY takes precedence", slog.String("path", *flagAuthKeyFile))
+			} else {
+				key, err := readAuthKeyFile(*flagAuthKeyFile)
+				if err != nil {
+					slog.Error("could not read authkey file", slog.String("path", *flagAuthKeyFile), slog.Any("error", err))
+					os.Exit(1)
+				}
+				ts.AuthKey = key
+				slog.Info("using auth key from file", slog.String("path", *flagAuthKeyFile))
+			}
 		}
 
 		if *flagAdvertiseTags != "" {
@@ -376,4 +394,16 @@ func envIntOr(envVar string, implicitValue int) int {
 		return implicitValue
 	}
 	return val
+}
+
+func readAuthKeyFile(path string) (string, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	key := strings.TrimSpace(string(b))
+	if key == "" {
+		return "", fmt.Errorf("authkey file %q is empty", path)
+	}
+	return key, nil
 }

--- a/tsidp-server.go
+++ b/tsidp-server.go
@@ -45,7 +45,7 @@ var (
 	flagDir                = flag.String("dir", envknob.String("TS_STATE_DIR"), "tsnet state directory; a default one will be created if not provided")
 	flagEnableSTS          = flag.Bool("enable-sts", envknob.Bool("TSIDP_ENABLE_STS"), "enable OIDC STS token exchange support")
 	flagAdvertiseTags      = flag.String("advertise-tags", envknob.String("TS_ADVERTISE_TAGS"), "comma-separated advertise tags (e.g. tag:tsidp,tag:server); required when using OAuth client secrets")
-	flagAuthKeyFile        = flag.String("authkey-file", envknob.String("TS_AUTHKEY_FILE"), "path to a file containing the Tailscale auth key (e.g. a Docker/Kubernetes secret); TS_AUTHKEY takes precedence if also set")
+	flagAuthKeyFile        = flag.String("authkey-file", envknob.String("TS_AUTHKEY_FILE"), "read the Tailscale auth key from this file instead of TS_AUTHKEY (e.g. for Docker/Kubernetes secrets); don't set both")
 
 	// application logging levels
 	flagLogLevel = flag.String("log", cmp.Or(envknob.String("TSIDP_LOG"), "info"), "log levels: debug, info, warn, error")
@@ -148,15 +148,17 @@ func main() {
 		}
 
 		if *flagAuthKeyFile != "" {
-			if v := cmp.Or(envknob.String("TS_AUTHKEY"), envknob.String("TS_AUTH_KEY")); v != "" {
-				slog.Warn("authkey-file ignored: TS_AUTHKEY/TS_AUTH_KEY takes precedence", slog.String("path", *flagAuthKeyFile))
-			} else {
-				key, err := readAuthKeyFile(*flagAuthKeyFile)
-				if err != nil {
-					slog.Error("could not read authkey file", slog.String("path", *flagAuthKeyFile), slog.Any("error", err))
-					os.Exit(1)
-				}
-				ts.AuthKey = key
+			explicitKeySet := cmp.Or(envknob.String("TS_AUTHKEY"), envknob.String("TS_AUTH_KEY")) != ""
+			res := resolveAuthKeyFile(*flagAuthKeyFile, explicitKeySet)
+			if res.fatal != "" {
+				slog.Error(res.fatal, slog.String("path", *flagAuthKeyFile))
+				os.Exit(1)
+			}
+			if res.warn != "" {
+				slog.Warn(res.warn, slog.String("path", *flagAuthKeyFile))
+			}
+			if res.key != "" {
+				ts.AuthKey = res.key
 				slog.Info("using auth key from file", slog.String("path", *flagAuthKeyFile))
 			}
 		}
@@ -406,4 +408,29 @@ func readAuthKeyFile(path string) (string, error) {
 		return "", fmt.Errorf("authkey file %q is empty", path)
 	}
 	return key, nil
+}
+
+// authKeyFileResult is the outcome of resolveAuthKeyFile: at most one of
+// fatal, warn, or key is set.
+type authKeyFileResult struct {
+	key   string // resolved auth key, if any
+	warn  string // non-fatal message to log and continue
+	fatal string // message to log before exiting
+}
+
+// resolveAuthKeyFile decides what to do with -authkey-file given whether
+// TS_AUTHKEY/TS_AUTH_KEY is also set explicitly.
+func resolveAuthKeyFile(path string, explicitKeySet bool) authKeyFileResult {
+	if explicitKeySet {
+		return authKeyFileResult{fatal: "-authkey-file and TS_AUTHKEY/TS_AUTH_KEY are mutually exclusive; unset one"}
+	}
+	key, err := readAuthKeyFile(path)
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		return authKeyFileResult{warn: "authkey file not found, continuing without it (node may already be registered)"}
+	case err != nil:
+		return authKeyFileResult{fatal: fmt.Sprintf("could not read authkey file: %v", err)}
+	default:
+		return authKeyFileResult{key: key}
+	}
 }

--- a/tsidp-server_test.go
+++ b/tsidp-server_test.go
@@ -49,21 +49,12 @@ func TestReadAuthKeyFileMissing(t *testing.T) {
 }
 
 func TestResolveAuthKeyFile(t *testing.T) {
-	t.Run("explicit key set", func(t *testing.T) {
-		// The path is never touched: explicitKeySet short-circuits before
-		// any file access, so it doesn't need to exist.
-		res := resolveAuthKeyFile("/should/not/be/read", true)
-		if res.fatal == "" || res.key != "" || res.warn != "" {
-			t.Fatalf("got %+v, want fatal set and key/warn empty", res)
-		}
-	})
-
 	t.Run("file missing", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "does-not-exist")
 
-		res := resolveAuthKeyFile(path, false)
-		if res.warn == "" || res.key != "" || res.fatal != "" {
-			t.Fatalf("got %+v, want warn set and key/fatal empty", res)
+		key, err := resolveAuthKeyFile(path)
+		if err != nil || key != "" {
+			t.Fatalf("got key=%q err=%v, want key=\"\" err=nil", key, err)
 		}
 	})
 
@@ -71,9 +62,9 @@ func TestResolveAuthKeyFile(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "authkey")
 		mustWriteFile(t, path, "")
 
-		res := resolveAuthKeyFile(path, false)
-		if res.fatal == "" || res.key != "" || res.warn != "" {
-			t.Fatalf("got %+v, want fatal set and key/warn empty", res)
+		key, err := resolveAuthKeyFile(path)
+		if err == nil || key != "" {
+			t.Fatalf("got key=%q err=%v, want key=\"\" err!=nil", key, err)
 		}
 	})
 
@@ -81,9 +72,9 @@ func TestResolveAuthKeyFile(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "authkey")
 		mustWriteFile(t, path, "tskey-auth-file\n")
 
-		res := resolveAuthKeyFile(path, false)
-		if res.key != "tskey-auth-file" || res.warn != "" || res.fatal != "" {
-			t.Fatalf("got %+v, want key=%q and warn/fatal empty", res, "tskey-auth-file")
+		key, err := resolveAuthKeyFile(path)
+		if err != nil || key != "tskey-auth-file" {
+			t.Fatalf("got key=%q err=%v, want key=%q err=nil", key, err, "tskey-auth-file")
 		}
 	})
 }

--- a/tsidp-server_test.go
+++ b/tsidp-server_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadAuthKeyFile(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+		wantErr bool
+	}{
+		{name: "plain key", content: "tskey-auth-abc123", want: "tskey-auth-abc123"},
+		{name: "trailing newline", content: "tskey-auth-abc123\n", want: "tskey-auth-abc123"},
+		{name: "surrounding whitespace", content: "  tskey-auth-abc123  \n", want: "tskey-auth-abc123"},
+		{name: "empty file", content: "", wantErr: true},
+		{name: "whitespace only", content: "   \n\t", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "authkey")
+			if err := os.WriteFile(path, []byte(tt.content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			got, err := readAuthKeyFile(path)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("readAuthKeyFile() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err == nil && got != tt.want {
+				t.Errorf("readAuthKeyFile() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReadAuthKeyFileMissing(t *testing.T) {
+	_, err := readAuthKeyFile(filepath.Join(t.TempDir(), "does-not-exist"))
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}

--- a/tsidp-server_test.go
+++ b/tsidp-server_test.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -42,7 +43,54 @@ func TestReadAuthKeyFile(t *testing.T) {
 
 func TestReadAuthKeyFileMissing(t *testing.T) {
 	_, err := readAuthKeyFile(filepath.Join(t.TempDir(), "does-not-exist"))
-	if err == nil {
-		t.Fatal("expected error for missing file, got nil")
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected os.ErrNotExist, got %v", err)
+	}
+}
+
+func TestResolveAuthKeyFile(t *testing.T) {
+	t.Run("explicit key set", func(t *testing.T) {
+		// The path is never touched: explicitKeySet short-circuits before
+		// any file access, so it doesn't need to exist.
+		res := resolveAuthKeyFile("/should/not/be/read", true)
+		if res.fatal == "" || res.key != "" || res.warn != "" {
+			t.Fatalf("got %+v, want fatal set and key/warn empty", res)
+		}
+	})
+
+	t.Run("file missing", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "does-not-exist")
+
+		res := resolveAuthKeyFile(path, false)
+		if res.warn == "" || res.key != "" || res.fatal != "" {
+			t.Fatalf("got %+v, want warn set and key/fatal empty", res)
+		}
+	})
+
+	t.Run("file empty", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "authkey")
+		mustWriteFile(t, path, "")
+
+		res := resolveAuthKeyFile(path, false)
+		if res.fatal == "" || res.key != "" || res.warn != "" {
+			t.Fatalf("got %+v, want fatal set and key/warn empty", res)
+		}
+	})
+
+	t.Run("file valid", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "authkey")
+		mustWriteFile(t, path, "tskey-auth-file\n")
+
+		res := resolveAuthKeyFile(path, false)
+		if res.key != "tskey-auth-file" || res.warn != "" || res.fatal != "" {
+			t.Fatalf("got %+v, want key=%q and warn/fatal empty", res, "tskey-auth-file")
+		}
+	})
+}
+
+func mustWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Adds `-authkey-file` / `TS_AUTHKEY_FILE` so tsidp can read the Tailscale auth key from a mounted file - needed for Docker/Kubernetes secrets, which are exposed as files, not env vars. 
  
  - `TS_AUTHKEY` / `TS_AUTH_KEY` still take precedence if set (warns when both given)
  - No-op under `-use-local-tailscaled` (warns)
  - Errors out on missing/empty file

Supersedes #115, per review feedback
